### PR TITLE
feat(inscription-club): add API auth and backend

### DIFF
--- a/app/components/inscription/club/Step2ClubInfo.vue
+++ b/app/components/inscription/club/Step2ClubInfo.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { z } from 'zod'
+import type { FormSubmitEvent } from '@nuxt/ui'
 import type { InscriptionClubData } from '~/composables/useInscriptionClub'
 
 const props = defineProps<{
@@ -10,23 +12,51 @@ const emit = defineEmits<{
   next: []
 }>()
 
-const isFormValid = computed(() => {
-  return props.data.clubName.trim() !== ''
-    && props.data.description.trim() !== ''
-    && props.data.postalCode.trim() !== ''
-    && props.data.city.trim() !== ''
-    && props.data.address.trim() !== ''
+const schema = z.object({
+  clubName: z.string().min(2, 'Le nom du club doit contenir au moins 2 caractères'),
+  website: z.string().url('URL invalide').optional().or(z.literal('')),
+  description: z.string().min(10, 'La description doit contenir au moins 10 caractères'),
+  postalCode: z.string().regex(/^\d{5}$/, 'Code postal invalide (5 chiffres)'),
+  city: z.string().min(2, 'La ville doit contenir au moins 2 caractères'),
+  address: z.string().min(5, 'L\'adresse doit contenir au moins 5 caractères')
 })
 
-function handleNext() {
-  if (isFormValid.value) {
-    emit('next')
-  }
+type Schema = z.output<typeof schema>
+
+const state = reactive<Schema>({
+  clubName: props.data.clubName,
+  website: props.data.website,
+  description: props.data.description,
+  postalCode: props.data.postalCode,
+  city: props.data.city,
+  address: props.data.address
+})
+
+watch(() => props.data, (newData) => {
+  state.clubName = newData.clubName
+  state.website = newData.website
+  state.description = newData.description
+  state.postalCode = newData.postalCode
+  state.city = newData.city
+  state.address = newData.address
+}, { deep: true })
+
+watch(state, (newState) => {
+  emit('update', 'clubName', newState.clubName)
+  emit('update', 'website', newState.website || '')
+  emit('update', 'description', newState.description)
+  emit('update', 'postalCode', newState.postalCode)
+  emit('update', 'city', newState.city)
+  emit('update', 'address', newState.address)
+}, { deep: true })
+
+function onSubmit(_event: FormSubmitEvent<Schema>) {
+  emit('next')
 }
 </script>
 
 <template>
-  <div class="flex flex-col gap-8">
+  <UForm :schema="schema" :state="state" class="flex flex-col gap-8" @submit="onSubmit">
     <!-- Titre et sous-titre -->
     <div class="flex flex-col gap-2">
       <h1 class="text-[30px] font-semibold text-[#1c1c1c] leading-[45px] tracking-tight font-asap">
@@ -40,40 +70,36 @@ function handleNext() {
     <!-- Formulaire -->
     <div class="flex flex-col gap-6">
       <!-- Nom du club -->
-      <div class="flex flex-col gap-2">
-        <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Nom du club *</label>
-        <input
-          :value="data.clubName"
-          type="text"
+      <UFormField label="Nom du club" name="clubName" required>
+        <UInput
+          v-model="state.clubName"
           placeholder="Nom du club"
-          class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 px-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-          @input="emit('update', 'clubName', ($event.target as HTMLInputElement).value)"
-        >
-      </div>
+          class="w-full"
+          size="lg"
+        />
+      </UFormField>
 
       <!-- Site web -->
-      <div class="flex flex-col gap-2">
-        <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Site web</label>
-        <input
-          :value="data.website"
+      <UFormField label="Site web" name="website" hint="Optionnel">
+        <UInput
+          v-model="state.website"
           type="url"
-          placeholder="Site web"
-          class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 px-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-          @input="emit('update', 'website', ($event.target as HTMLInputElement).value)"
-        >
-      </div>
+          placeholder="https://monclub.fr"
+          class="w-full"
+          size="lg"
+        />
+      </UFormField>
 
       <!-- Description du club -->
-      <div class="flex flex-col gap-2">
-        <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Description du club *</label>
-        <textarea
-          :value="data.description"
+      <UFormField label="Description du club" name="description" required>
+        <UTextarea
+          v-model="state.description"
           placeholder="(Historique, valeurs, sports proposés)"
-          rows="4"
-          class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg px-3 py-2 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e] resize-none"
-          @input="emit('update', 'description', ($event.target as HTMLTextAreaElement).value)"
+          :rows="4"
+          class="w-full"
+          size="lg"
         />
-      </div>
+      </UFormField>
 
       <!-- Section Adresse -->
       <div class="flex flex-col gap-4">
@@ -83,52 +109,46 @@ function handleNext() {
 
         <!-- Code postal et Ville -->
         <div class="grid grid-cols-2 gap-3">
-          <div class="flex flex-col gap-2">
-            <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Code postal *</label>
-            <input
-              :value="data.postalCode"
-              type="text"
+          <UFormField label="Code postal" name="postalCode" required>
+            <UInput
+              v-model="state.postalCode"
               placeholder="59000"
-              class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 px-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-              @input="emit('update', 'postalCode', ($event.target as HTMLInputElement).value)"
-            >
-          </div>
-          <div class="flex flex-col gap-2">
-            <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Ville *</label>
-            <input
-              :value="data.city"
-              type="text"
+              class="w-full"
+              size="lg"
+            />
+          </UFormField>
+
+          <UFormField label="Ville" name="city" required>
+            <UInput
+              v-model="state.city"
               placeholder="Lille"
-              class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 px-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-              @input="emit('update', 'city', ($event.target as HTMLInputElement).value)"
-            >
-          </div>
+              class="w-full"
+              size="lg"
+            />
+          </UFormField>
         </div>
 
         <!-- Adresse -->
-        <div class="flex flex-col gap-2">
-          <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Adresse *</label>
-          <input
-            :value="data.address"
-            type="text"
+        <UFormField label="Adresse" name="address" required>
+          <UInput
+            v-model="state.address"
             placeholder="37 Rue Pierre Mauroy"
-            class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 px-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-            @input="emit('update', 'address', ($event.target as HTMLInputElement).value)"
-          >
-        </div>
+            class="w-full"
+            size="lg"
+          />
+        </UFormField>
       </div>
     </div>
 
     <!-- Bouton Continuer -->
     <UButton
+      type="submit"
       block
-      :disabled="!isFormValid"
-      class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! font-montserrat! text-base! rounded-[50px]! py-3! disabled:opacity-50! disabled:cursor-not-allowed!"
-      @click="handleNext"
+      class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! font-montserrat! text-base! rounded-[50px]! py-3!"
     >
       Continuer
     </UButton>
-  </div>
+  </UForm>
 </template>
 
 <style scoped>

--- a/app/components/inscription/club/Step3PersonalInfo.vue
+++ b/app/components/inscription/club/Step3PersonalInfo.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { z } from 'zod'
+import type { FormSubmitEvent } from '@nuxt/ui'
 import type { InscriptionClubData } from '~/composables/useInscriptionClub'
 
 const props = defineProps<{
@@ -11,24 +13,54 @@ const emit = defineEmits<{
   submit: []
 }>()
 
-const isFormValid = computed(() => {
-  return props.data.firstName.trim() !== ''
-    && props.data.lastName.trim() !== ''
-    && props.data.email.trim() !== ''
-    && props.data.phone.trim() !== ''
-    && props.data.password.length >= 8
-    && props.data.password === props.data.confirmPassword
+const schema = z.object({
+  firstName: z.string().min(2, 'Le prénom doit contenir au moins 2 caractères'),
+  lastName: z.string().min(2, 'Le nom doit contenir au moins 2 caractères'),
+  email: z.string().email('Adresse email invalide'),
+  phone: z.string().min(10, 'Numéro de téléphone invalide'),
+  password: z.string().min(8, 'Le mot de passe doit contenir au moins 8 caractères'),
+  confirmPassword: z.string().min(8, 'La confirmation est requise')
+}).refine(data => data.password === data.confirmPassword, {
+  message: 'Les mots de passe ne correspondent pas',
+  path: ['confirmPassword']
 })
 
-function handleSubmit() {
-  if (isFormValid.value) {
-    emit('submit')
-  }
+type Schema = z.output<typeof schema>
+
+const state = reactive<Schema>({
+  firstName: props.data.firstName,
+  lastName: props.data.lastName,
+  email: props.data.email,
+  phone: props.data.phone,
+  password: props.data.password,
+  confirmPassword: props.data.confirmPassword
+})
+
+watch(() => props.data, (newData) => {
+  state.firstName = newData.firstName
+  state.lastName = newData.lastName
+  state.email = newData.email
+  state.phone = newData.phone
+  state.password = newData.password
+  state.confirmPassword = newData.confirmPassword
+}, { deep: true })
+
+watch(state, (newState) => {
+  emit('update', 'firstName', newState.firstName)
+  emit('update', 'lastName', newState.lastName)
+  emit('update', 'email', newState.email)
+  emit('update', 'phone', newState.phone)
+  emit('update', 'password', newState.password)
+  emit('update', 'confirmPassword', newState.confirmPassword)
+}, { deep: true })
+
+function onSubmit(_event: FormSubmitEvent<Schema>) {
+  emit('submit')
 }
 </script>
 
 <template>
-  <div class="flex flex-col gap-8">
+  <UForm :schema="schema" :state="state" class="flex flex-col gap-8" @submit="onSubmit">
     <!-- Titre et sous-titre -->
     <div class="flex flex-col gap-2">
       <h1 class="text-[30px] font-semibold text-[#1c1c1c] leading-[45px] tracking-tight font-asap">
@@ -43,164 +75,89 @@ function handleSubmit() {
     <div class="flex flex-col gap-6">
       <!-- Prénom et Nom -->
       <div class="grid grid-cols-2 gap-4">
-        <div class="flex flex-col gap-2">
-          <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Prénom *</label>
-          <input
-            :value="data.firstName"
-            type="text"
+        <UFormField label="Prénom" name="firstName" required>
+          <UInput
+            v-model="state.firstName"
             placeholder="Prénom"
-            class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 px-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-            @input="emit('update', 'firstName', ($event.target as HTMLInputElement).value)"
-          >
-        </div>
-        <div class="flex flex-col gap-2">
-          <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Nom *</label>
-          <input
-            :value="data.lastName"
-            type="text"
+            class="w-full"
+            size="lg"
+          />
+        </UFormField>
+
+        <UFormField label="Nom" name="lastName" required>
+          <UInput
+            v-model="state.lastName"
             placeholder="Nom"
-            class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 px-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-            @input="emit('update', 'lastName', ($event.target as HTMLInputElement).value)"
-          >
-        </div>
+            class="w-full"
+            size="lg"
+          />
+        </UFormField>
       </div>
 
       <!-- Adresse e-mail -->
-      <div class="flex flex-col gap-2">
-        <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Adresse e-mail *</label>
-        <div class="relative">
-          <input
-            :value="data.email"
-            type="email"
-            placeholder="Adresse e-mail"
-            class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 pl-12 pr-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-            @input="emit('update', 'email', ($event.target as HTMLInputElement).value)"
-          >
-          <svg
-            class="absolute left-4 top-1/2 -translate-y-1/2 text-[#545454]"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M4 4H20C21.1 4 22 4.9 22 6V18C22 19.1 21.1 20 20 20H4C2.9 20 2 19.1 2 18V6C2 4.9 2.9 4 4 4Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-            <path d="M22 6L12 13L2 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </div>
-      </div>
+      <UFormField label="Adresse e-mail" name="email" required>
+        <UInput
+          v-model="state.email"
+          type="email"
+          placeholder="Adresse e-mail"
+          class="w-full"
+          size="lg"
+          icon="i-heroicons-envelope"
+        />
+      </UFormField>
 
       <!-- Numéro de téléphone -->
-      <div class="flex flex-col gap-2">
-        <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Numéro de téléphone *</label>
-        <div class="relative">
-          <input
-            :value="data.phone"
-            type="tel"
-            placeholder="Numéro de téléphone"
-            class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 pl-12 pr-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-            @input="emit('update', 'phone', ($event.target as HTMLInputElement).value)"
-          >
-          <svg
-            class="absolute left-4 top-1/2 -translate-y-1/2 text-[#545454]"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path d="M22 16.92V19.92C22.0011 20.1985 21.9441 20.4742 21.8325 20.7294C21.7209 20.9845 21.5573 21.2136 21.3521 21.4019C21.1469 21.5901 20.9046 21.7335 20.6408 21.8227C20.3769 21.9119 20.0974 21.9451 19.82 21.92C16.7428 21.5856 13.787 20.5341 11.19 18.85C8.77383 17.3147 6.72534 15.2662 5.19 12.85C3.49998 10.2412 2.44824 7.27097 2.12 4.18C2.09501 3.90344 2.12788 3.62476 2.2165 3.36162C2.30513 3.09849 2.44757 2.85668 2.63477 2.65162C2.82196 2.44656 3.04981 2.28271 3.30379 2.17052C3.55778 2.05833 3.83234 2.00026 4.11 2H7.11C7.59531 1.99522 8.06579 2.16708 8.43376 2.48353C8.80173 2.79999 9.04208 3.23945 9.11 3.72C9.23662 4.68006 9.47145 5.62272 9.81 6.53C9.94455 6.88792 9.97366 7.27691 9.89391 7.65088C9.81415 8.02485 9.62886 8.36811 9.36 8.64L8.09 9.91C9.51356 12.4135 11.5865 14.4864 14.09 15.91L15.36 14.64C15.6319 14.3711 15.9752 14.1858 16.3491 14.1061C16.7231 14.0263 17.1121 14.0555 17.47 14.19C18.3773 14.5286 19.3199 14.7634 20.28 14.89C20.7658 14.9585 21.2094 15.2032 21.5265 15.5775C21.8437 15.9518 22.0122 16.4296 22 16.92Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </div>
-      </div>
+      <UFormField label="Numéro de téléphone" name="phone" required>
+        <UInput
+          v-model="state.phone"
+          type="tel"
+          placeholder="Numéro de téléphone"
+          class="w-full"
+          size="lg"
+          icon="i-heroicons-phone"
+        />
+      </UFormField>
 
       <!-- Mot de passe -->
-      <div class="flex flex-col gap-2">
-        <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Mot de passe *</label>
-        <div class="relative">
-          <input
-            :value="data.password"
-            type="password"
-            placeholder="Mot de passe"
-            class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 pl-12 pr-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-            @input="emit('update', 'password', ($event.target as HTMLInputElement).value)"
-          >
-          <svg
-            class="absolute left-4 top-1/2 -translate-y-1/2 text-[#545454]"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <rect
-              x="3"
-              y="11"
-              width="18"
-              height="11"
-              rx="2"
-              ry="2"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-            <path d="M7 11V7C7 5.67392 7.52678 4.40215 8.46447 3.46447C9.40215 2.52678 10.6739 2 12 2C13.3261 2 14.5979 2.52678 15.5355 3.46447C16.4732 4.40215 17 5.67392 17 7V11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </div>
-      </div>
+      <UFormField label="Mot de passe" name="password" required>
+        <UInput
+          v-model="state.password"
+          type="password"
+          placeholder="Mot de passe"
+          class="w-full"
+          size="lg"
+          icon="i-heroicons-lock-closed"
+        />
+      </UFormField>
 
       <!-- Confirmation du mot de passe -->
-      <div class="flex flex-col gap-2">
-        <label class="text-base text-[#1c1c1c] leading-6 font-roboto">Confirmation du mot de passe *</label>
-        <div class="relative">
-          <input
-            :value="data.confirmPassword"
-            type="password"
-            placeholder="Confirmation du mot de passe"
-            class="w-full bg-[#f7f7f7] border-2 border-[#e5e7eb] rounded-lg h-12 pl-12 pr-3 text-sm text-[#1c1c1c] placeholder-[#545454] font-roboto focus:outline-none focus:border-[#ef781e]"
-            @input="emit('update', 'confirmPassword', ($event.target as HTMLInputElement).value)"
-          >
-          <svg
-            class="absolute left-4 top-1/2 -translate-y-1/2 text-[#545454]"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <rect
-              x="3"
-              y="11"
-              width="18"
-              height="11"
-              rx="2"
-              ry="2"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            />
-            <path d="M7 11V7C7 5.67392 7.52678 4.40215 8.46447 3.46447C9.40215 2.52678 10.6739 2 12 2C13.3261 2 14.5979 2.52678 15.5355 3.46447C16.4732 4.40215 17 5.67392 17 7V11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </div>
-        <p class="text-xs text-[#545454] leading-4 font-roboto">
-          Cela doit être une combinaison d'au moins 8 lettres, chiffres et symboles.
-        </p>
-      </div>
+      <UFormField
+        label="Confirmation du mot de passe"
+        name="confirmPassword"
+        required
+        help="Cela doit être une combinaison d'au moins 8 lettres, chiffres et symboles."
+      >
+        <UInput
+          v-model="state.confirmPassword"
+          type="password"
+          placeholder="Confirmation du mot de passe"
+          class="w-full"
+          size="lg"
+          icon="i-heroicons-lock-closed"
+        />
+      </UFormField>
     </div>
 
     <!-- Bouton Continuer -->
     <UButton
+      type="submit"
       block
-      :disabled="!isFormValid || isLoading"
       :loading="isLoading"
-      class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! font-montserrat! text-base! rounded-[50px]! py-3! disabled:opacity-50! disabled:cursor-not-allowed!"
-      @click="handleSubmit"
+      class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! font-montserrat! text-base! rounded-[50px]! py-3!"
     >
       Continuer
     </UButton>
-  </div>
+  </UForm>
 </template>
 
 <style scoped>

--- a/app/composables/useInscriptionClub.ts
+++ b/app/composables/useInscriptionClub.ts
@@ -25,6 +25,11 @@ export interface InscriptionClubState {
   data: InscriptionClubData
   isLoading: boolean
   error: string | null
+  // Email verification
+  verificationId: string | null
+  emailVerified: boolean
+  // Club registration
+  clubId: string | null
 }
 
 export const TOTAL_STEPS_CLUB = 4
@@ -52,7 +57,10 @@ export const useInscriptionClub = () => {
       confirmPassword: ''
     },
     isLoading: false,
-    error: null
+    error: null,
+    verificationId: null,
+    emailVerified: false,
+    clubId: null
   }))
 
   const currentStep = computed({
@@ -117,7 +125,10 @@ export const useInscriptionClub = () => {
         confirmPassword: ''
       },
       isLoading: false,
-      error: null
+      error: null,
+      verificationId: null,
+      emailVerified: false,
+      clubId: null
     }
   }
 

--- a/app/pages/inscription/club/index.vue
+++ b/app/pages/inscription/club/index.vue
@@ -16,6 +16,12 @@ const {
 
 const toast = useToast()
 
+// OTP verification state
+const showOtpModal = ref(false)
+const otpCode = ref('')
+const otpLoading = ref(false)
+const otpError = ref<string | null>(null)
+
 // Update sports array
 function handleSportsUpdate(sports: string[]) {
   updateData('sports', sports)
@@ -34,31 +40,157 @@ function handleBack() {
   }
 }
 
-// Handle final submission
+// Step 1: Send OTP when form is submitted
 async function handleSubmit() {
   state.value.isLoading = true
   state.value.error = null
 
   try {
-    // TODO: API call to register
-    console.log('Registration data:', state.value.data)
-
-    toast.add({
-      title: 'Inscription réussie !',
-      description: 'Bienvenue sur Sportly !',
-      color: 'success'
+    // Send OTP to verify email
+    const response = await $fetch('/api/auth/send-otp', {
+      method: 'POST',
+      body: {
+        email: state.value.data.email,
+        firstName: state.value.data.firstName
+      }
     })
 
-    await navigateTo('/app/club')
-  } catch (error) {
-    console.error('Registration error:', error)
+    if (response.success) {
+      showOtpModal.value = true
+      toast.add({
+        title: 'Code envoyé',
+        description: 'Un code de vérification a été envoyé à votre adresse email',
+        color: 'success'
+      })
+    }
+  } catch (error: unknown) {
+    console.error('Send OTP error:', error)
+    const errorMessage = error && typeof error === 'object' && 'data' in error
+      ? (error.data as { message?: string })?.message || 'Une erreur est survenue'
+      : 'Une erreur est survenue'
     toast.add({
       title: 'Erreur',
-      description: 'Une erreur est survenue lors de l\'inscription',
+      description: errorMessage,
       color: 'error'
     })
   } finally {
     state.value.isLoading = false
+  }
+}
+
+// Step 2: Verify OTP
+async function handleVerifyOtp() {
+  if (otpCode.value.length !== 6) {
+    otpError.value = 'Le code doit contenir 6 chiffres'
+    return
+  }
+
+  otpLoading.value = true
+  otpError.value = null
+
+  try {
+    const response = await $fetch('/api/auth/verify-otp', {
+      method: 'POST',
+      body: {
+        email: state.value.data.email,
+        code: otpCode.value
+      }
+    })
+
+    if (response.success) {
+      state.value.verificationId = response.verificationId
+      state.value.emailVerified = true
+      showOtpModal.value = false
+
+      // Proceed to create club
+      await handleCreateClub()
+    }
+  } catch (error: unknown) {
+    console.error('Verify OTP error:', error)
+    otpError.value = error && typeof error === 'object' && 'data' in error
+      ? (error.data as { message?: string })?.message || 'Code invalide'
+      : 'Code invalide'
+  } finally {
+    otpLoading.value = false
+  }
+}
+
+// Step 3: Create club account
+async function handleCreateClub() {
+  state.value.isLoading = true
+
+  try {
+    const response = await $fetch<{ success: boolean, clubId: string }>('/api/clubs', {
+      method: 'POST',
+      body: {
+        verificationId: state.value.verificationId,
+        sports: state.value.data.sports,
+        clubName: state.value.data.clubName,
+        website: state.value.data.website,
+        description: state.value.data.description,
+        postalCode: state.value.data.postalCode,
+        city: state.value.data.city,
+        address: state.value.data.address,
+        firstName: state.value.data.firstName,
+        lastName: state.value.data.lastName,
+        phone: state.value.data.phone,
+        password: state.value.data.password
+      }
+    })
+
+    if (response.success) {
+      state.value.clubId = response.clubId
+      toast.add({
+        title: 'Club créé !',
+        description: 'Votre club a été créé avec succès',
+        color: 'success'
+      })
+
+      // Navigate to offer selection
+      await navigateTo('/inscription/club/offre')
+    }
+  } catch (error: unknown) {
+    console.error('Create club error:', error)
+    const errorMessage = error && typeof error === 'object' && 'data' in error
+      ? (error.data as { message?: string })?.message || 'Une erreur est survenue'
+      : 'Une erreur est survenue'
+    toast.add({
+      title: 'Erreur',
+      description: errorMessage,
+      color: 'error'
+    })
+  } finally {
+    state.value.isLoading = false
+  }
+}
+
+// Resend OTP
+async function handleResendOtp() {
+  otpLoading.value = true
+  otpError.value = null
+
+  try {
+    await $fetch('/api/auth/send-otp', {
+      method: 'POST',
+      body: {
+        email: state.value.data.email,
+        firstName: state.value.data.firstName
+      }
+    })
+
+    toast.add({
+      title: 'Code renvoyé',
+      description: 'Un nouveau code a été envoyé à votre adresse email',
+      color: 'success'
+    })
+    otpCode.value = ''
+  } catch (error: unknown) {
+    console.error('Resend OTP error:', error)
+    otpError.value = error && typeof error === 'object' && 'data' in error
+      ? (error.data as { message?: string })?.message || 'Une erreur est survenue'
+      : 'Une erreur est survenue'
+  } finally {
+    otpLoading.value = false
   }
 }
 </script>
@@ -116,6 +248,64 @@ async function handleSubmit() {
         />
       </Transition>
     </main>
+
+    <!-- OTP Verification Modal -->
+    <UModal v-model:open="showOtpModal">
+      <template #content>
+        <div class="p-6">
+          <div class="flex flex-col items-center gap-6">
+            <div class="text-5xl">
+              📧
+            </div>
+
+            <div class="text-center">
+              <h2 class="text-xl font-semibold text-gray-900 mb-2">
+                Vérifiez votre email
+              </h2>
+              <p class="text-gray-600">
+                Un code de vérification a été envoyé à
+                <span class="font-medium">{{ state.data.email }}</span>
+              </p>
+            </div>
+
+            <div class="w-full max-w-xs">
+              <UFormField label="Code de vérification" :error="otpError || undefined">
+                <UInput
+                  v-model="otpCode"
+                  placeholder="000000"
+                  class="w-full text-center text-2xl tracking-widest"
+                  size="xl"
+                  maxlength="6"
+                  inputmode="numeric"
+                  pattern="[0-9]*"
+                />
+              </UFormField>
+            </div>
+
+            <div class="flex flex-col gap-3 w-full max-w-xs">
+              <UButton
+                block
+                :loading="otpLoading"
+                :disabled="otpCode.length !== 6"
+                class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! rounded-[50px]! py-3!"
+                @click="handleVerifyOtp"
+              >
+                Vérifier
+              </UButton>
+
+              <button
+                type="button"
+                class="text-sm text-gray-500 hover:text-gray-700 underline"
+                :disabled="otpLoading"
+                @click="handleResendOtp"
+              >
+                Renvoyer le code
+              </button>
+            </div>
+          </div>
+        </div>
+      </template>
+    </UModal>
   </div>
 </template>
 

--- a/app/pages/inscription/club/offre.vue
+++ b/app/pages/inscription/club/offre.vue
@@ -3,9 +3,13 @@ definePageMeta({
   layout: false
 })
 
+const { state, resetState } = useInscriptionClub()
+const toast = useToast()
+
 type OfferType = 'essentiel' | 'visibilite'
 
 const selectedOffer = ref<OfferType>('essentiel')
+const isLoading = ref(false)
 
 const offers = {
   essentiel: {
@@ -40,12 +44,55 @@ const offers = {
 }
 
 function goBack() {
-  navigateTo('/inscription/club?step=3')
+  navigateTo('/inscription/club?step=4')
 }
 
-function goNext() {
-  console.log('Selected offer:', selectedOffer.value)
-  navigateTo('/inscription/club/success')
+async function goNext() {
+  if (!state.value.clubId) {
+    toast.add({
+      title: 'Erreur',
+      description: 'Aucun club trouvé. Veuillez recommencer l\'inscription.',
+      color: 'error'
+    })
+    navigateTo('/inscription/club')
+    return
+  }
+
+  isLoading.value = true
+
+  try {
+    const offerType = selectedOffer.value === 'essentiel' ? 'ESSENTIEL' : 'VISIBILITE'
+
+    await $fetch('/api/clubs/offer', {
+      method: 'POST',
+      body: {
+        clubId: state.value.clubId,
+        offerType
+      }
+    })
+
+    toast.add({
+      title: 'Inscription terminée !',
+      description: 'Votre club est maintenant actif sur Sportly',
+      color: 'success'
+    })
+
+    // Reset state and navigate to success
+    resetState()
+    navigateTo('/inscription/club/success')
+  } catch (error: unknown) {
+    console.error('Save offer error:', error)
+    const errorMessage = error && typeof error === 'object' && 'data' in error
+      ? (error.data as { message?: string })?.message || 'Une erreur est survenue'
+      : 'Une erreur est survenue'
+    toast.add({
+      title: 'Erreur',
+      description: errorMessage,
+      color: 'error'
+    })
+  } finally {
+    isLoading.value = false
+  }
 }
 </script>
 
@@ -187,6 +234,7 @@ function goNext() {
       <div class="pt-4 border-t border-[#d6d6d6]">
         <UButton
           block
+          :loading="isLoading"
           class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! font-montserrat! text-base! rounded-[50px]! py-3!"
           @click="goNext"
         >

--- a/server/api/clubs/index.post.ts
+++ b/server/api/clubs/index.post.ts
@@ -1,0 +1,137 @@
+import { z } from 'zod'
+import { eq, and, isNotNull } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { emailVerifications, accounts, clubs, addresses } from '../../db/schema'
+import { auth } from '../../utils/auth'
+import { sendWelcomeEmail } from '../../services/email'
+
+const clubRegistrationSchema = z.object({
+  verificationId: z.string().min(1, 'ID de vérification requis'),
+  sports: z.array(z.string()).min(1, 'Sélectionnez au moins un sport'),
+  clubName: z.string().min(2, 'Le nom du club doit contenir au moins 2 caractères'),
+  website: z.string().url('URL invalide').optional().or(z.literal('')),
+  description: z.string().min(10, 'La description doit contenir au moins 10 caractères'),
+  postalCode: z.string().regex(/^\d{5}$/, 'Code postal invalide (5 chiffres)'),
+  city: z.string().min(2, 'La ville doit contenir au moins 2 caractères'),
+  address: z.string().min(5, 'L\'adresse doit contenir au moins 5 caractères'),
+  firstName: z.string().min(2, 'Le prénom doit contenir au moins 2 caractères'),
+  lastName: z.string().min(2, 'Le nom doit contenir au moins 2 caractères'),
+  phone: z.string().min(10, 'Numéro de téléphone invalide'),
+  password: z.string().min(8, 'Le mot de passe doit contenir au moins 8 caractères')
+})
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+
+  // Validation avec Zod
+  const parseResult = clubRegistrationSchema.safeParse(body)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Données invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const data = parseResult.data
+  const db = useDrizzle()
+
+  try {
+    // 1. Vérifier que l'email a bien été vérifié
+    const verifications = await db
+      .select()
+      .from(emailVerifications)
+      .where(
+        and(
+          eq(emailVerifications.id, data.verificationId),
+          isNotNull(emailVerifications.verifiedAt)
+        )
+      )
+      .limit(1)
+
+    const verification = verifications[0]
+    if (!verification) {
+      throw createError({
+        statusCode: 400,
+        message: 'Vérification d\'email invalide ou expirée. Veuillez recommencer l\'inscription.'
+      })
+    }
+
+    const email = verification.email
+
+    // 2. Créer le compte avec Better Auth (type CLUB)
+    const name = `${data.firstName} ${data.lastName}`
+    const signUpResult = await auth().api.signUpEmail({
+      body: {
+        email,
+        password: data.password,
+        name
+      }
+    })
+
+    if (!signUpResult || !signUpResult.user) {
+      throw createError({
+        statusCode: 400,
+        message: 'Échec de la création du compte'
+      })
+    }
+
+    const accountId = signUpResult.user.id
+
+    // 3. Mettre à jour le type de compte en CLUB
+    await db
+      .update(accounts)
+      .set({
+        accountType: 'CLUB',
+        phone: data.phone
+      })
+      .where(eq(accounts.id, accountId))
+
+    // 4. Créer l'entrée dans la table clubs
+    await db.insert(clubs).values({
+      accountId,
+      clubName: data.clubName,
+      description: data.description,
+      websiteUrl: data.website || null,
+      phone: data.phone,
+      email,
+      sports: data.sports,
+      adminFirstName: data.firstName,
+      adminLastName: data.lastName,
+      verificationId: data.verificationId,
+      registrationStatus: 'PENDING'
+    })
+
+    // 5. Créer l'adresse du club
+    await db.insert(addresses).values({
+      accountId,
+      line1: data.address,
+      postalCode: data.postalCode,
+      city: data.city,
+      isPrimary: true
+    })
+
+    // 6. Envoyer l'email de bienvenue (non-bloquant)
+    sendWelcomeEmail(email, data.firstName).catch((err) => {
+      console.error('Erreur envoi email de bienvenue:', err)
+    })
+
+    return {
+      success: true,
+      message: 'Club créé avec succès',
+      clubId: accountId,
+      user: signUpResult.user
+    }
+  } catch (error: unknown) {
+    // Re-throw les erreurs HTTP déjà formatées
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur création club:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la création du club'
+    })
+  }
+})

--- a/server/api/clubs/offer.post.ts
+++ b/server/api/clubs/offer.post.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod'
+import { eq } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { clubs } from '../../db/schema'
+
+const clubOfferSchema = z.object({
+  clubId: z.string().min(1, 'ID du club requis'),
+  offerType: z.enum(['ESSENTIEL', 'VISIBILITE'], {
+    errorMap: () => ({ message: 'Type d\'offre invalide' })
+  })
+})
+
+export default defineEventHandler(async (event) => {
+  const body = await readBody(event)
+
+  // Validation avec Zod
+  const parseResult = clubOfferSchema.safeParse(body)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Données invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const { clubId, offerType } = parseResult.data
+  const db = useDrizzle()
+
+  try {
+    // Vérifier que le club existe
+    const existingClub = await db
+      .select({ accountId: clubs.accountId })
+      .from(clubs)
+      .where(eq(clubs.accountId, clubId))
+      .limit(1)
+
+    if (existingClub.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: 'Club non trouvé'
+      })
+    }
+
+    // Mettre à jour l'offre et le statut
+    await db
+      .update(clubs)
+      .set({
+        offerType,
+        registrationStatus: 'COMPLETED'
+      })
+      .where(eq(clubs.accountId, clubId))
+
+    return {
+      success: true,
+      message: 'Offre enregistrée avec succès',
+      offerType
+    }
+  } catch (error: unknown) {
+    // Re-throw les erreurs HTTP déjà formatées
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur mise à jour offre:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la mise à jour de l\'offre'
+    })
+  }
+})

--- a/server/db/migrations/0002_remarkable_shen.sql
+++ b/server/db/migrations/0002_remarkable_shen.sql
@@ -1,0 +1,8 @@
+CREATE TYPE "public"."club_offer_type" AS ENUM('ESSENTIEL', 'VISIBILITE');--> statement-breakpoint
+CREATE TYPE "public"."club_registration_status" AS ENUM('DRAFT', 'PENDING', 'VERIFIED', 'COMPLETED');--> statement-breakpoint
+ALTER TABLE "clubs" ADD COLUMN "registration_status" "club_registration_status" DEFAULT 'DRAFT' NOT NULL;--> statement-breakpoint
+ALTER TABLE "clubs" ADD COLUMN "offer_type" "club_offer_type" DEFAULT 'ESSENTIEL';--> statement-breakpoint
+ALTER TABLE "clubs" ADD COLUMN "sports" text[];--> statement-breakpoint
+ALTER TABLE "clubs" ADD COLUMN "admin_first_name" varchar(80);--> statement-breakpoint
+ALTER TABLE "clubs" ADD COLUMN "admin_last_name" varchar(80);--> statement-breakpoint
+ALTER TABLE "clubs" ADD COLUMN "verification_id" text;

--- a/server/db/migrations/meta/0002_snapshot.json
+++ b/server/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,2097 @@
+{
+  "id": "6f34eb4a-19b0-483a-b017-e5851be2ab53",
+  "prevId": "0de4dede-e2b3-41c6-a9da-2dd061bb652f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_email_unique": {
+          "name": "accounts_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_account_id_accounts_id_fk": {
+          "name": "oauth_accounts_account_id_accounts_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.password_resets": {
+      "name": "password_resets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_resets_account_id_accounts_id_fk": {
+          "name": "password_resets_account_id_accounts_id_fk",
+          "tableFrom": "password_resets",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_account_id_accounts_id_fk": {
+          "name": "sessions_account_id_accounts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.verification_codes": {
+      "name": "verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "otp_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verification_codes_account_id_accounts_id_fk": {
+          "name": "verification_codes_account_id_accounts_id_fk",
+          "tableFrom": "verification_codes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.email_verifications": {
+      "name": "email_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.addresses": {
+      "name": "addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line1": {
+          "name": "line1",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line2": {
+          "name": "line2",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FR'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "addresses_account_id_accounts_id_fk": {
+          "name": "addresses_account_id_accounts_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.clubs": {
+      "name": "clubs",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "club_name": {
+          "name": "club_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_open": {
+          "name": "is_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_media_id": {
+          "name": "logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "club_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "offer_type": {
+          "name": "offer_type",
+          "type": "club_offer_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ESSENTIEL'"
+        },
+        "sports": {
+          "name": "sports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_first_name": {
+          "name": "admin_first_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_last_name": {
+          "name": "admin_last_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_id": {
+          "name": "verification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clubs_account_id_accounts_id_fk": {
+          "name": "clubs_account_id_accounts_id_fk",
+          "tableFrom": "clubs",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.media_files": {
+      "name": "media_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_files_owner_account_id_accounts_id_fk": {
+          "name": "media_files_owner_account_id_accounts_id_fk",
+          "tableFrom": "media_files",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_search_prefs": {
+      "name": "user_search_prefs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base_address_id": {
+          "name": "base_address_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius_km": {
+          "name": "radius_km",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20.0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_search_prefs_user_id_users_account_id_fk": {
+          "name": "user_search_prefs_user_id_users_account_id_fk",
+          "tableFrom": "user_search_prefs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_search_prefs_base_address_id_addresses_id_fk": {
+          "name": "user_search_prefs_base_address_id_addresses_id_fk",
+          "tableFrom": "user_search_prefs",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "base_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_id": {
+          "name": "profile_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_account_id_accounts_id_fk": {
+          "name": "users_account_id_accounts_id_fk",
+          "tableFrom": "users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_facilities": {
+      "name": "club_facilities",
+      "schema": "",
+      "columns": {
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility": {
+          "name": "facility",
+          "type": "facility_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_facilities_club_id_clubs_account_id_fk": {
+          "name": "club_facilities_club_id_clubs_account_id_fk",
+          "tableFrom": "club_facilities",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_opening_exceptions": {
+      "name": "club_opening_exceptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_covered": {
+          "name": "date_covered",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_time": {
+          "name": "open_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_time": {
+          "name": "close_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_opening_exceptions_club_id_clubs_account_id_fk": {
+          "name": "club_opening_exceptions_club_id_clubs_account_id_fk",
+          "tableFrom": "club_opening_exceptions",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_opening_hours": {
+      "name": "club_opening_hours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "weekday",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "morning_open": {
+          "name": "morning_open",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "morning_close": {
+          "name": "morning_close",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afternoon_open": {
+          "name": "afternoon_open",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afternoon_close": {
+          "name": "afternoon_close",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_opening_hours_club_id_clubs_account_id_fk": {
+          "name": "club_opening_hours_club_id_clubs_account_id_fk",
+          "tableFrom": "club_opening_hours",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_photos": {
+      "name": "club_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_photos_club_id_clubs_account_id_fk": {
+          "name": "club_photos_club_id_clubs_account_id_fk",
+          "tableFrom": "club_photos",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_reviews": {
+      "name": "club_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_reviews_club_id_clubs_account_id_fk": {
+          "name": "club_reviews_club_id_clubs_account_id_fk",
+          "tableFrom": "club_reviews",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_sports": {
+      "name": "club_sports",
+      "schema": "",
+      "columns": {
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_id": {
+          "name": "sport_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "levels_accepted": {
+          "name": "levels_accepted",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audiences": {
+          "name": "audiences",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_sports_club_id_clubs_account_id_fk": {
+          "name": "club_sports_club_id_clubs_account_id_fk",
+          "tableFrom": "club_sports",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "club_sports_sport_id_sports_id_fk": {
+          "name": "club_sports_sport_id_sports_id_fk",
+          "tableFrom": "club_sports",
+          "tableTo": "sports",
+          "columnsFrom": [
+            "sport_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sports": {
+      "name": "sports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sports_code_unique": {
+          "name": "sports_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.event_participants": {
+      "name": "event_participants",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REGISTERED'"
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_participants_event_id_events_id_fk": {
+          "name": "event_participants_event_id_events_id_fk",
+          "tableFrom": "event_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.event_payments": {
+      "name": "event_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_payment_id": {
+          "name": "provider_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_payments_event_id_events_id_fk": {
+          "name": "event_payments_event_id_events_id_fk",
+          "tableFrom": "event_payments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.event_photos": {
+      "name": "event_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_photos_event_id_events_id_fk": {
+          "name": "event_photos_event_id_events_id_fk",
+          "tableFrom": "event_photos",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.event_sports": {
+      "name": "event_sports",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_id": {
+          "name": "sport_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_sports_event_id_events_id_fk": {
+          "name": "event_sports_event_id_events_id_fk",
+          "tableFrom": "event_sports",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_sports_sport_id_sports_id_fk": {
+          "name": "event_sports_sport_id_sports_id_fk",
+          "tableFrom": "event_sports",
+          "tableTo": "sports",
+          "columnsFrom": [
+            "sport_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_required": {
+          "name": "level_required",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessibility": {
+          "name": "accessibility",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_provider": {
+          "name": "payment_provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_organizer_id_accounts_id_fk": {
+          "name": "events_organizer_id_accounts_id_fk",
+          "tableFrom": "events",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_address_id_addresses_id_fk": {
+          "name": "events_address_id_addresses_id_fk",
+          "tableFrom": "events",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.admin_logs": {
+      "name": "admin_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_logs_actor_id_accounts_id_fk": {
+          "name": "admin_logs_actor_id_accounts_id_fk",
+          "tableFrom": "admin_logs",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_rooms": {
+      "name": "club_rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_media_id": {
+          "name": "photo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_type": {
+          "name": "room_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_rooms_club_id_clubs_account_id_fk": {
+          "name": "club_rooms_club_id_clubs_account_id_fk",
+          "tableFrom": "club_rooms",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_account_id_accounts_id_fk": {
+          "name": "notifications_account_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_reporter_id_accounts_id_fk": {
+          "name": "reports_reporter_id_accounts_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_code": {
+          "name": "plan_code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_club_id_clubs_account_id_fk": {
+          "name": "subscriptions_club_id_clubs_account_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_connections": {
+      "name": "user_connections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "USER",
+        "CLUB"
+      ]
+    },
+    "public.club_offer_type": {
+      "name": "club_offer_type",
+      "schema": "public",
+      "values": [
+        "ESSENTIEL",
+        "VISIBILITE"
+      ]
+    },
+    "public.club_registration_status": {
+      "name": "club_registration_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PENDING",
+        "VERIFIED",
+        "COMPLETED"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "STAGE",
+        "TOURNOI",
+        "ENTRAINEMENT",
+        "DECOUVERTE"
+      ]
+    },
+    "public.facility_type": {
+      "name": "facility_type",
+      "schema": "public",
+      "values": [
+        "HANDICAP_FRIENDLY",
+        "VESTIAIRES",
+        "TOILETTES"
+      ]
+    },
+    "public.otp_channel": {
+      "name": "otp_channel",
+      "schema": "public",
+      "values": [
+        "EMAIL",
+        "SMS"
+      ]
+    },
+    "public.sport_level": {
+      "name": "sport_level",
+      "schema": "public",
+      "values": [
+        "DEBUTANT",
+        "INTERMEDIAIRE",
+        "AVANCE",
+        "PRO"
+      ]
+    },
+    "public.target_audience": {
+      "name": "target_audience",
+      "schema": "public",
+      "values": [
+        "ENFANTS",
+        "ADOS",
+        "ADULTES",
+        "SENIORS",
+        "TOUS"
+      ]
+    },
+    "public.weekday": {
+      "name": "weekday",
+      "schema": "public",
+      "values": [
+        "LUN",
+        "MAR",
+        "MER",
+        "JEU",
+        "VEN",
+        "SAM",
+        "DIM"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1768310036784,
       "tag": "0001_spotty_dexter_bennett",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1770127891968,
+      "tag": "0002_remarkable_shen",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/enums.ts
+++ b/server/db/schema/enums.ts
@@ -8,3 +8,7 @@ export const sportLevelEnum = pgEnum('sport_level', ['DEBUTANT', 'INTERMEDIAIRE'
 export const targetAudienceEnum = pgEnum('target_audience', ['ENFANTS', 'ADOS', 'ADULTES', 'SENIORS', 'TOUS'])
 export const facilityTypeEnum = pgEnum('facility_type', ['HANDICAP_FRIENDLY', 'VESTIAIRES', 'TOILETTES'])
 export const weekdayEnum = pgEnum('weekday', ['LUN', 'MAR', 'MER', 'JEU', 'VEN', 'SAM', 'DIM'])
+
+// Enums pour l'inscription club
+export const clubRegistrationStatusEnum = pgEnum('club_registration_status', ['DRAFT', 'PENDING', 'VERIFIED', 'COMPLETED'])
+export const clubOfferTypeEnum = pgEnum('club_offer_type', ['ESSENTIEL', 'VISIBILITE'])

--- a/server/db/schema/users.ts
+++ b/server/db/schema/users.ts
@@ -1,5 +1,6 @@
 import { pgTable, uuid, varchar, text, numeric, integer, boolean, date, timestamp, doublePrecision, char } from 'drizzle-orm/pg-core'
 import { accounts } from './auth'
+import { clubRegistrationStatusEnum, clubOfferTypeEnum } from './enums'
 
 // Table des utilisateurs
 export const users = pgTable('users', {
@@ -21,7 +22,15 @@ export const clubs = pgTable('clubs', {
   websiteUrl: text('website_url'),
   phone: varchar('phone', { length: 32 }),
   email: varchar('email', { length: 120 }),
-  logoMediaId: uuid('logo_media_id') // Référence vers media_files
+  logoMediaId: uuid('logo_media_id'), // Référence vers media_files
+
+  // Champs pour l'inscription club
+  registrationStatus: clubRegistrationStatusEnum('registration_status').notNull().default('DRAFT'),
+  offerType: clubOfferTypeEnum('offer_type').default('ESSENTIEL'),
+  sports: text('sports').array(), // Sports proposés par le club
+  adminFirstName: varchar('admin_first_name', { length: 80 }),
+  adminLastName: varchar('admin_last_name', { length: 80 }),
+  verificationId: text('verification_id') // Référence vers la vérification email
 })
 
 // Table des adresses

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+// Schémas de validation partagés pour l'inscription club
+
+export const clubInfoSchema = z.object({
+  sports: z.array(z.string()).min(1, 'Sélectionnez au moins un sport'),
+  clubName: z.string().min(2, 'Le nom du club doit contenir au moins 2 caractères'),
+  website: z.string().url('URL invalide').optional().or(z.literal('')),
+  description: z.string().min(10, 'La description doit contenir au moins 10 caractères'),
+  postalCode: z.string().regex(/^\d{5}$/, 'Code postal invalide (5 chiffres)'),
+  city: z.string().min(2, 'La ville doit contenir au moins 2 caractères'),
+  address: z.string().min(5, 'L\'adresse doit contenir au moins 5 caractères')
+})
+
+export const adminInfoSchema = z.object({
+  firstName: z.string().min(2, 'Le prénom doit contenir au moins 2 caractères'),
+  lastName: z.string().min(2, 'Le nom doit contenir au moins 2 caractères'),
+  email: z.string().email('Adresse email invalide'),
+  phone: z.string().min(10, 'Numéro de téléphone invalide'),
+  password: z.string().min(8, 'Le mot de passe doit contenir au moins 8 caractères')
+})
+
+export const clubRegistrationSchema = clubInfoSchema.merge(adminInfoSchema).extend({
+  verificationId: z.string().min(1, 'ID de vérification requis')
+})
+
+export const clubOfferSchema = z.object({
+  clubId: z.string().min(1, 'ID du club requis'),
+  offerType: z.enum(['ESSENTIEL', 'VISIBILITE'])
+})
+
+export type ClubInfo = z.infer<typeof clubInfoSchema>
+export type AdminInfo = z.infer<typeof adminInfoSchema>
+export type ClubRegistration = z.infer<typeof clubRegistrationSchema>
+export type ClubOffer = z.infer<typeof clubOfferSchema>


### PR DESCRIPTION
Resolves #19 

## Summary

Shortened implementation of the club registration flow with API auth and backend persistence.

- Adds Zod-based validation and `UForm` usage to club info (step 2) and admin info (step 3) forms.
- Extends `useInscriptionClub` state with `verificationId`, `emailVerified`, and `clubId`.
- Implements OTP-based email verification (send, verify, resend) on `/inscription/club`, with modal UI and toasts.
- Creates `POST /api/clubs` to:
  - validate payload (club + admin info + verificationId),
  - check email verification,
  - create Better Auth account as `CLUB`,
  - insert club + address data,
  - send welcome email.
- Creates `POST /api/clubs/offer` to save selected offer (`ESSENTIEL` / `VISIBILITE`) and mark registration as `COMPLETED`.
- Updates DB schema (enums + `clubs` fields: registrationStatus, offerType, sports, admin names, verificationId).

## Testing

- Go through the full club inscription flow (steps 1–4) and verify:
  - client-side validation errors are shown as expected,
  - OTP send/verify/resend behavior,
  - club creation and redirect to offer page,
  - offer saving and redirect to success page,
  - `clubs` and `addresses` entries are correctly populated in the DB.
  
