### PR TITLE
feat(api-clubs): add CRUD endpoints for clubs

### DIFF
--- a/server/api/clubs/[id].get.ts
+++ b/server/api/clubs/[id].get.ts
@@ -1,0 +1,116 @@
+import { eq } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import {
+  clubs,
+  addresses,
+  clubSports,
+  sports,
+  clubFacilities,
+  clubOpeningHours,
+  clubPhotos,
+  mediaFiles,
+  clubReviews
+} from '../../db/schema'
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID du club requis'
+    })
+  }
+
+  const db = useDrizzle()
+
+  try {
+    // 1. Club de base
+    const clubResult = await db
+      .select()
+      .from(clubs)
+      .where(eq(clubs.accountId, id))
+      .limit(1)
+
+    const club = clubResult[0]
+    if (!club) {
+      throw createError({
+        statusCode: 404,
+        message: 'Club non trouvé'
+      })
+    }
+
+    // 2. Adresse principale
+    const addressResult = await db
+      .select()
+      .from(addresses)
+      .where(eq(addresses.accountId, id))
+
+    // 3. Sports du club
+    const clubSportsResult = await db
+      .select({
+        sportId: clubSports.sportId,
+        code: sports.code,
+        label: sports.label,
+        emoji: sports.emoji,
+        levelsAccepted: clubSports.levelsAccepted,
+        audiences: clubSports.audiences
+      })
+      .from(clubSports)
+      .innerJoin(sports, eq(sports.id, clubSports.sportId))
+      .where(eq(clubSports.clubId, id))
+
+    // 4. Équipements
+    const facilitiesResult = await db
+      .select({ facility: clubFacilities.facility })
+      .from(clubFacilities)
+      .where(eq(clubFacilities.clubId, id))
+
+    // 5. Horaires d'ouverture
+    const hoursResult = await db
+      .select()
+      .from(clubOpeningHours)
+      .where(eq(clubOpeningHours.clubId, id))
+
+    // 6. Photos
+    const photosResult = await db
+      .select({
+        id: clubPhotos.id,
+        storagePath: mediaFiles.storagePath,
+        mimeType: mediaFiles.mimeType,
+        createdAt: clubPhotos.createdAt
+      })
+      .from(clubPhotos)
+      .leftJoin(mediaFiles, eq(mediaFiles.id, clubPhotos.mediaId))
+      .where(eq(clubPhotos.clubId, id))
+
+    // 7. Avis (résumé)
+    const reviewsResult = await db
+      .select()
+      .from(clubReviews)
+      .where(eq(clubReviews.clubId, id))
+
+    return {
+      ...club,
+      addresses: addressResult,
+      sports: clubSportsResult,
+      facilities: facilitiesResult.map(f => f.facility),
+      openingHours: hoursResult,
+      photos: photosResult,
+      reviews: {
+        count: reviewsResult.length,
+        items: reviewsResult.slice(0, 5)
+      }
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur détail club:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la récupération du club'
+    })
+  }
+})

--- a/server/api/clubs/[id].put.ts
+++ b/server/api/clubs/[id].put.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod'
+import { eq } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { clubs, addresses } from '../../db/schema'
+import { serverAuth } from '../../utils/auth'
+
+const updateClubSchema = z.object({
+  clubName: z.string().min(2).optional(),
+  description: z.string().min(10).optional(),
+  websiteUrl: z.string().url().optional().or(z.literal('')),
+  phone: z.string().min(10).optional(),
+  email: z.string().email().optional(),
+  isOpen: z.boolean().optional(),
+  sports: z.array(z.string()).min(1).optional(),
+  address: z.object({
+    line1: z.string().min(5).optional(),
+    line2: z.string().optional(),
+    postalCode: z.string().regex(/^\d{5}$/).optional(),
+    city: z.string().min(2).optional(),
+    latitude: z.number().optional(),
+    longitude: z.number().optional()
+  }).optional()
+})
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID du club requis'
+    })
+  }
+
+  // Vérifier l'authentification
+  const session = await serverAuth().api.getSession({
+    headers: event.headers
+  })
+
+  if (!session?.user) {
+    throw createError({
+      statusCode: 401,
+      message: 'Authentification requise'
+    })
+  }
+
+  // Vérifier que l'utilisateur est bien le propriétaire du club
+  if (session.user.id !== id) {
+    throw createError({
+      statusCode: 403,
+      message: 'Vous n\'êtes pas autorisé à modifier ce club'
+    })
+  }
+
+  const body = await readBody(event)
+
+  const parseResult = updateClubSchema.safeParse(body)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Données invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const data = parseResult.data
+  const db = useDrizzle()
+
+  try {
+    // Vérifier que le club existe
+    const existingClub = await db
+      .select({ accountId: clubs.accountId })
+      .from(clubs)
+      .where(eq(clubs.accountId, id))
+      .limit(1)
+
+    if (existingClub.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: 'Club non trouvé'
+      })
+    }
+
+    // Mettre à jour les infos du club
+    const { address: addressData, ...clubData } = data
+
+    if (Object.keys(clubData).length > 0) {
+      await db
+        .update(clubs)
+        .set(clubData)
+        .where(eq(clubs.accountId, id))
+    }
+
+    // Mettre à jour l'adresse si fournie
+    if (addressData && Object.keys(addressData).length > 0) {
+      await db
+        .update(addresses)
+        .set(addressData)
+        .where(eq(addresses.accountId, id))
+    }
+
+    // Retourner le club mis à jour
+    const updatedClub = await db
+      .select()
+      .from(clubs)
+      .where(eq(clubs.accountId, id))
+      .limit(1)
+
+    return {
+      success: true,
+      message: 'Club mis à jour avec succès',
+      data: updatedClub[0]
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur mise à jour club:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la mise à jour du club'
+    })
+  }
+})

--- a/server/api/clubs/[id]/reviews.get.ts
+++ b/server/api/clubs/[id]/reviews.get.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod'
+import { eq, sql } from 'drizzle-orm'
+import { useDrizzle } from '../../../utils/drizzle'
+import { clubs, clubReviews } from '../../../db/schema'
+
+const querySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0)
+})
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID du club requis'
+    })
+  }
+
+  const query = getQuery(event)
+
+  const parseResult = querySchema.safeParse(query)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Paramètres invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const { limit, offset } = parseResult.data
+  const db = useDrizzle()
+
+  try {
+    // Vérifier que le club existe
+    const clubResult = await db
+      .select({ accountId: clubs.accountId })
+      .from(clubs)
+      .where(eq(clubs.accountId, id))
+      .limit(1)
+
+    if (clubResult.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: 'Club non trouvé'
+      })
+    }
+
+    // Compter le total d'avis
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(clubReviews)
+      .where(eq(clubReviews.clubId, id))
+
+    const total = Number(countResult[0]?.count ?? 0)
+
+    // Moyenne des notes
+    const avgResult = await db
+      .select({ avg: sql<number>`coalesce(avg(${clubReviews.rating}), 0)` })
+      .from(clubReviews)
+      .where(eq(clubReviews.clubId, id))
+
+    const averageRating = Number(Number(avgResult[0]?.avg ?? 0).toFixed(1))
+
+    // Récupérer les avis paginés
+    const reviews = await db
+      .select()
+      .from(clubReviews)
+      .where(eq(clubReviews.clubId, id))
+      .orderBy(clubReviews.createdAt)
+      .limit(limit)
+      .offset(offset)
+
+    return {
+      data: reviews,
+      total,
+      averageRating,
+      limit,
+      offset
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur avis club:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la récupération des avis'
+    })
+  }
+})

--- a/server/api/clubs/index.get.ts
+++ b/server/api/clubs/index.get.ts
@@ -1,0 +1,128 @@
+import { z } from 'zod'
+import { eq, sql, and, inArray } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { clubs, addresses, clubSports, clubFacilities } from '../../db/schema'
+
+const querySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+  sport: z.string().optional(),
+  city: z.string().optional(),
+  isOpen: z.enum(['true', 'false']).optional(),
+  level: z.string().optional(),
+  facility: z.string().optional()
+})
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+
+  const parseResult = querySchema.safeParse(query)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Paramètres invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const { limit, offset, sport, city, isOpen, level, facility } = parseResult.data
+  const db = useDrizzle()
+
+  try {
+    // Construire les conditions de filtrage
+    const conditions = []
+
+    if (isOpen !== undefined) {
+      conditions.push(eq(clubs.isOpen, isOpen === 'true'))
+    }
+
+    if (city) {
+      conditions.push(eq(addresses.city, city))
+    }
+
+    // Filtre par sport (cherche dans le text array clubs.sports ET dans clubSports)
+    if (sport) {
+      conditions.push(sql`${sport} = ANY(${clubs.sports})`)
+    }
+
+    // Filtre par niveau (DEBUTANT, INTERMEDIAIRE, AVANCE, PRO)
+    if (level) {
+      const matchingClubs = await db
+        .select({ clubId: clubSports.clubId })
+        .from(clubSports)
+        .where(sql`${level} = ANY(${clubSports.levelsAccepted})`)
+
+      const clubIds = matchingClubs.map(c => c.clubId)
+      if (clubIds.length === 0) return { data: [], total: 0, limit, offset }
+      conditions.push(inArray(clubs.accountId, clubIds))
+    }
+
+    // Filtre par accessibilité (HANDICAP_FRIENDLY, VESTIAIRES, TOILETTES)
+    if (facility) {
+      const matchingClubs = await db
+        .select({ clubId: clubFacilities.clubId })
+        .from(clubFacilities)
+        .where(eq(clubFacilities.facility, facility as any))
+
+      const clubIds = matchingClubs.map(c => c.clubId)
+      if (clubIds.length === 0) return { data: [], total: 0, limit, offset }
+      conditions.push(inArray(clubs.accountId, clubIds))
+    }
+
+    // Compter le total
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined
+
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(clubs)
+      .leftJoin(addresses, and(eq(addresses.accountId, clubs.accountId), eq(addresses.isPrimary, true)))
+      .where(whereClause)
+
+    const total = Number(countResult[0]?.count ?? 0)
+
+    // Récupérer les clubs avec adresse
+    const clubsList = await db
+      .select({
+        accountId: clubs.accountId,
+        clubName: clubs.clubName,
+        description: clubs.description,
+        rating: clubs.rating,
+        reviewCount: clubs.reviewCount,
+        isOpen: clubs.isOpen,
+        websiteUrl: clubs.websiteUrl,
+        phone: clubs.phone,
+        email: clubs.email,
+        sports: clubs.sports,
+        offerType: clubs.offerType,
+        address: {
+          line1: addresses.line1,
+          postalCode: addresses.postalCode,
+          city: addresses.city,
+          latitude: addresses.latitude,
+          longitude: addresses.longitude
+        }
+      })
+      .from(clubs)
+      .leftJoin(addresses, and(eq(addresses.accountId, clubs.accountId), eq(addresses.isPrimary, true)))
+      .where(whereClause)
+      .limit(limit)
+      .offset(offset)
+
+    return {
+      data: clubsList,
+      total,
+      limit,
+      offset
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur liste clubs:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la récupération des clubs'
+    })
+  }
+})

--- a/server/api/clubs/search.get.ts
+++ b/server/api/clubs/search.get.ts
@@ -1,0 +1,109 @@
+import { z } from 'zod'
+import { sql, and, eq } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { clubs, addresses } from '../../db/schema'
+
+const querySchema = z.object({
+  lat: z.coerce.number().min(-90).max(90),
+  lng: z.coerce.number().min(-180).max(180),
+  radius: z.coerce.number().min(1).max(100).default(20),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0)
+})
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+
+  const parseResult = querySchema.safeParse(query)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Paramètres invalides (lat, lng requis)',
+      data: parseResult.error.errors
+    })
+  }
+
+  const { lat, lng, radius, limit, offset } = parseResult.data
+  const db = useDrizzle()
+
+  try {
+    // Formule Haversine pour calculer la distance en km
+    const distanceFormula = sql<number>`
+      6371 * acos(
+        cos(radians(${lat}))
+        * cos(radians(${addresses.latitude}))
+        * cos(radians(${addresses.longitude}) - radians(${lng}))
+        + sin(radians(${lat}))
+        * sin(radians(${addresses.latitude}))
+      )
+    `
+
+    // Compter le total dans le rayon
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(clubs)
+      .innerJoin(addresses, and(
+        eq(addresses.accountId, clubs.accountId),
+        eq(addresses.isPrimary, true)
+      ))
+      .where(sql`${addresses.latitude} IS NOT NULL AND ${addresses.longitude} IS NOT NULL AND ${distanceFormula} <= ${radius}`)
+
+    const total = Number(countResult[0]?.count ?? 0)
+
+    // Récupérer les clubs dans le rayon, triés par distance
+    const results = await db
+      .select({
+        accountId: clubs.accountId,
+        clubName: clubs.clubName,
+        description: clubs.description,
+        rating: clubs.rating,
+        reviewCount: clubs.reviewCount,
+        isOpen: clubs.isOpen,
+        phone: clubs.phone,
+        email: clubs.email,
+        sports: clubs.sports,
+        address: {
+          line1: addresses.line1,
+          postalCode: addresses.postalCode,
+          city: addresses.city,
+          latitude: addresses.latitude,
+          longitude: addresses.longitude
+        },
+        distance: distanceFormula
+      })
+      .from(clubs)
+      .innerJoin(addresses, and(
+        eq(addresses.accountId, clubs.accountId),
+        eq(addresses.isPrimary, true)
+      ))
+      .where(sql`${addresses.latitude} IS NOT NULL AND ${addresses.longitude} IS NOT NULL AND ${distanceFormula} <= ${radius}`)
+      .orderBy(distanceFormula)
+      .limit(limit)
+      .offset(offset)
+
+    // Arrondir les distances
+    const data = results.map(r => ({
+      ...r,
+      distance: Number(Number(r.distance).toFixed(2))
+    }))
+
+    return {
+      data,
+      total,
+      radius,
+      center: { lat, lng },
+      limit,
+      offset
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur recherche géolocalisée:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la recherche géolocalisée'
+    })
+  }
+})


### PR DESCRIPTION
## Description

Implémentation des endpoints API CRUD pour les clubs, conformément à l'issue #23.

### Endpoints ajoutés

- `GET /api/clubs` — Liste paginée avec filtres (sport, ville, niveau, accessibilité, isOpen)
- `GET /api/clubs/:id` — Détail complet d'un club avec toutes les relations
- `PUT /api/clubs/:id` — Mise à jour (propriétaire uniquement, protégé par auth)
- `GET /api/clubs/:id/reviews` — Avis paginés d'un club avec moyenne des notes
- `GET /api/clubs/search` — Recherche géolocalisée (Haversine, lat/lng + rayon en km)

### Critères d'acceptation

- [x] `GET /api/clubs` retourne la liste paginée avec filtres
- [x] `GET /api/clubs/:id` retourne le club avec toutes les relations
- [x] `PUT /api/clubs/:id` protégé par auth (propriétaire uniquement)
- [x] Recherche géolocalisée fonctionnelle (lat/lng + rayon)
- [x] Validation Zod sur tous les inputs
- [x] Pagination avec `limit` et `offset`

### Notes techniques

- Tables utilisées : `clubs`, `addresses`, `clubSports`, `sports`, `clubFacilities`, `clubOpeningHours`, `clubPhotos`, `clubReviews`
- Auth : `serverAuth().api.getSession()`
- ORM : Drizzle avec `useDrizzle()`

Closes #23