### PR TITLE
feat(api-events): add CRUD endpoints for events

### DIFF
--- a/server/api/events/[id].delete.ts
+++ b/server/api/events/[id].delete.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod'
+import { eq } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { events, eventSports, eventPhotos, eventParticipants } from '../../db/schema'
+import { serverAuth } from '../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !z.string().uuid().safeParse(id).success) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID de l\'événement invalide'
+    })
+  }
+
+  // Vérifier l'authentification
+  const session = await serverAuth().api.getSession({
+    headers: event.headers
+  })
+
+  if (!session?.user) {
+    throw createError({
+      statusCode: 401,
+      message: 'Authentification requise'
+    })
+  }
+
+  const db = useDrizzle()
+
+  // Vérifier que l'événement existe et que l'utilisateur est le propriétaire
+  const existingEvent = await db
+    .select({ organizerId: events.organizerId })
+    .from(events)
+    .where(eq(events.id, id))
+    .limit(1)
+
+  if (existingEvent.length === 0) {
+    throw createError({
+      statusCode: 404,
+      message: 'Événement non trouvé'
+    })
+  }
+
+  if (existingEvent[0]!.organizerId !== session.user.id) {
+    throw createError({
+      statusCode: 403,
+      message: 'Vous n\'êtes pas autorisé à supprimer cet événement'
+    })
+  }
+
+  try {
+    // Supprimer les données liées puis l'événement
+    await db.delete(eventParticipants).where(eq(eventParticipants.eventId, id))
+    await db.delete(eventPhotos).where(eq(eventPhotos.eventId, id))
+    await db.delete(eventSports).where(eq(eventSports.eventId, id))
+    await db.delete(events).where(eq(events.id, id))
+
+    return {
+      success: true,
+      message: 'Événement supprimé avec succès'
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur suppression événement:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la suppression de l\'événement'
+    })
+  }
+})

--- a/server/api/events/[id].get.ts
+++ b/server/api/events/[id].get.ts
@@ -1,0 +1,107 @@
+import { z } from 'zod'
+import { eq, sql } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import {
+  events,
+  addresses,
+  eventSports,
+  sports,
+  eventPhotos,
+  mediaFiles,
+  eventParticipants
+} from '../../db/schema'
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !z.string().uuid().safeParse(id).success) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID de l\'événement invalide'
+    })
+  }
+
+  const db = useDrizzle()
+
+  try {
+    // 1. Événement de base
+    const eventResult = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, id))
+      .limit(1)
+
+    const evt = eventResult[0]
+    if (!evt) {
+      throw createError({
+        statusCode: 404,
+        message: 'Événement non trouvé'
+      })
+    }
+
+    // 2. Adresse
+    let address = null
+    if (evt.addressId) {
+      const addressResult = await db
+        .select()
+        .from(addresses)
+        .where(eq(addresses.id, evt.addressId))
+        .limit(1)
+      address = addressResult[0] ?? null
+    }
+
+    // 3. Sports liés
+    const sportsResult = await db
+      .select({
+        sportId: eventSports.sportId,
+        code: sports.code,
+        label: sports.label,
+        emoji: sports.emoji
+      })
+      .from(eventSports)
+      .innerJoin(sports, eq(sports.id, eventSports.sportId))
+      .where(eq(eventSports.eventId, id))
+
+    // 4. Photos
+    const photosResult = await db
+      .select({
+        id: eventPhotos.id,
+        storagePath: mediaFiles.storagePath,
+        mimeType: mediaFiles.mimeType,
+        createdAt: eventPhotos.createdAt
+      })
+      .from(eventPhotos)
+      .leftJoin(mediaFiles, eq(mediaFiles.id, eventPhotos.mediaId))
+      .where(eq(eventPhotos.eventId, id))
+
+    // 5. Nombre de participants inscrits
+    const participantCountResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(eventParticipants)
+      .where(eq(eventParticipants.eventId, id))
+
+    const participantCount = Number(participantCountResult[0]?.count ?? 0)
+
+    return {
+      ...evt,
+      address,
+      sports: sportsResult,
+      photos: photosResult,
+      participants: {
+        count: participantCount,
+        max: evt.maxParticipants,
+        isFull: evt.maxParticipants ? participantCount >= evt.maxParticipants : false
+      }
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur détail événement:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la récupération de l\'événement'
+    })
+  }
+})

--- a/server/api/events/[id].put.ts
+++ b/server/api/events/[id].put.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod'
+import { eq } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { events } from '../../db/schema'
+import { serverAuth } from '../../utils/auth'
+
+const updateEventSchema = z.object({
+  eventType: z.enum(['STAGE', 'TOURNOI', 'ENTRAINEMENT', 'DECOUVERTE']).optional(),
+  title: z.string().min(3).max(160).optional(),
+  description: z.string().min(10).optional(),
+  addressId: z.string().uuid().optional(),
+  startTime: z.string().datetime().optional(),
+  endTime: z.string().datetime().optional(),
+  levelRequired: z.array(z.string()).min(1).optional(),
+  audience: z.array(z.string()).min(1).optional(),
+  accessibility: z.array(z.string()).optional(),
+  paymentProvider: z.string().max(40).optional(),
+  price: z.coerce.number().min(0).optional(),
+  maxParticipants: z.coerce.number().int().min(1).optional()
+})
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !z.string().uuid().safeParse(id).success) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID de l\'événement invalide'
+    })
+  }
+
+  // Vérifier l'authentification
+  const session = await serverAuth().api.getSession({
+    headers: event.headers
+  })
+
+  if (!session?.user) {
+    throw createError({
+      statusCode: 401,
+      message: 'Authentification requise'
+    })
+  }
+
+  const db = useDrizzle()
+
+  // Vérifier que l'événement existe et que l'utilisateur est le propriétaire
+  const existingEvent = await db
+    .select({ organizerId: events.organizerId })
+    .from(events)
+    .where(eq(events.id, id))
+    .limit(1)
+
+  if (existingEvent.length === 0) {
+    throw createError({
+      statusCode: 404,
+      message: 'Événement non trouvé'
+    })
+  }
+
+  if (existingEvent[0]!.organizerId !== session.user.id) {
+    throw createError({
+      statusCode: 403,
+      message: 'Vous n\'êtes pas autorisé à modifier cet événement'
+    })
+  }
+
+  const body = await readBody(event)
+
+  const parseResult = updateEventSchema.safeParse(body)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Données invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const data = parseResult.data
+
+  // Vérifier cohérence dates si fournies
+  if (data.startTime && data.endTime) {
+    if (new Date(data.startTime) >= new Date(data.endTime)) {
+      throw createError({
+        statusCode: 400,
+        message: 'La date de début doit être antérieure à la date de fin'
+      })
+    }
+  }
+
+  try {
+    const updateData: Record<string, unknown> = { ...data }
+    if (data.startTime) updateData.startTime = new Date(data.startTime)
+    if (data.endTime) updateData.endTime = new Date(data.endTime)
+    if (data.price !== undefined) updateData.price = String(data.price)
+
+    await db
+      .update(events)
+      .set(updateData)
+      .where(eq(events.id, id))
+
+    const updatedEvent = await db
+      .select()
+      .from(events)
+      .where(eq(events.id, id))
+      .limit(1)
+
+    return {
+      success: true,
+      message: 'Événement mis à jour avec succès',
+      data: updatedEvent[0]
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur mise à jour événement:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la mise à jour de l\'événement'
+    })
+  }
+})

--- a/server/api/events/[id]/participants.get.ts
+++ b/server/api/events/[id]/participants.get.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod'
+import { eq, and, sql } from 'drizzle-orm'
+import { useDrizzle } from '../../../utils/drizzle'
+import { events, eventParticipants, accounts } from '../../../db/schema'
+import { serverAuth } from '../../../utils/auth'
+
+const querySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+  status: z.enum(['REGISTERED', 'CANCELLED', 'ATTENDED']).optional()
+})
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !z.string().uuid().safeParse(id).success) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID de l\'événement invalide'
+    })
+  }
+
+  // Vérifier l'authentification
+  const session = await serverAuth().api.getSession({
+    headers: event.headers
+  })
+
+  if (!session?.user) {
+    throw createError({
+      statusCode: 401,
+      message: 'Authentification requise'
+    })
+  }
+
+  const db = useDrizzle()
+
+  // Vérifier que l'événement existe et que l'utilisateur est l'organisateur
+  const eventResult = await db
+    .select({ organizerId: events.organizerId })
+    .from(events)
+    .where(eq(events.id, id))
+    .limit(1)
+
+  if (eventResult.length === 0) {
+    throw createError({
+      statusCode: 404,
+      message: 'Événement non trouvé'
+    })
+  }
+
+  if (eventResult[0]!.organizerId !== session.user.id) {
+    throw createError({
+      statusCode: 403,
+      message: 'Seul l\'organisateur peut voir les participants'
+    })
+  }
+
+  const query = getQuery(event)
+
+  const parseResult = querySchema.safeParse(query)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Paramètres invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const { limit, offset, status } = parseResult.data
+
+  try {
+    const conditions = [eq(eventParticipants.eventId, id)]
+
+    if (status) {
+      conditions.push(eq(eventParticipants.status, status))
+    }
+
+    const whereClause = and(...conditions)
+
+    // Compter le total
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(eventParticipants)
+      .where(whereClause)
+
+    const total = Number(countResult[0]?.count ?? 0)
+
+    // Récupérer les participants avec infos du compte
+    const participants = await db
+      .select({
+        userId: eventParticipants.userId,
+        status: eventParticipants.status,
+        registeredAt: eventParticipants.registeredAt,
+        name: accounts.name,
+        email: accounts.email
+      })
+      .from(eventParticipants)
+      .innerJoin(accounts, eq(accounts.id, eventParticipants.userId))
+      .where(whereClause)
+      .orderBy(eventParticipants.registeredAt)
+      .limit(limit)
+      .offset(offset)
+
+    return {
+      data: participants,
+      total,
+      limit,
+      offset
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur liste participants:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la récupération des participants'
+    })
+  }
+})

--- a/server/api/events/[id]/register.delete.ts
+++ b/server/api/events/[id]/register.delete.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod'
+import { eq, and } from 'drizzle-orm'
+import { useDrizzle } from '../../../utils/drizzle'
+import { events, eventParticipants } from '../../../db/schema'
+import { serverAuth } from '../../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !z.string().uuid().safeParse(id).success) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID de l\'événement invalide'
+    })
+  }
+
+  // Vérifier l'authentification
+  const session = await serverAuth().api.getSession({
+    headers: event.headers
+  })
+
+  if (!session?.user) {
+    throw createError({
+      statusCode: 401,
+      message: 'Authentification requise'
+    })
+  }
+
+  const db = useDrizzle()
+
+  try {
+    // Vérifier que l'événement existe
+    const eventResult = await db
+      .select({ id: events.id })
+      .from(events)
+      .where(eq(events.id, id))
+      .limit(1)
+
+    if (eventResult.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: 'Événement non trouvé'
+      })
+    }
+
+    // Vérifier que l'utilisateur est inscrit
+    const registration = await db
+      .select()
+      .from(eventParticipants)
+      .where(and(
+        eq(eventParticipants.eventId, id),
+        eq(eventParticipants.userId, session.user.id)
+      ))
+      .limit(1)
+
+    if (registration.length === 0 || registration[0]!.status === 'CANCELLED') {
+      throw createError({
+        statusCode: 404,
+        message: 'Aucune inscription trouvée pour cet événement'
+      })
+    }
+
+    // Passer le statut à CANCELLED
+    await db
+      .update(eventParticipants)
+      .set({ status: 'CANCELLED' })
+      .where(and(
+        eq(eventParticipants.eventId, id),
+        eq(eventParticipants.userId, session.user.id)
+      ))
+
+    return {
+      success: true,
+      message: 'Désinscription confirmée'
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur désinscription événement:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la désinscription'
+    })
+  }
+})

--- a/server/api/events/[id]/register.post.ts
+++ b/server/api/events/[id]/register.post.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod'
+import { eq, and, sql } from 'drizzle-orm'
+import { useDrizzle } from '../../../utils/drizzle'
+import { events, eventParticipants } from '../../../db/schema'
+import { serverAuth } from '../../../utils/auth'
+
+export default defineEventHandler(async (event) => {
+  const id = getRouterParam(event, 'id')
+
+  if (!id || !z.string().uuid().safeParse(id).success) {
+    throw createError({
+      statusCode: 400,
+      message: 'ID de l\'événement invalide'
+    })
+  }
+
+  // Vérifier l'authentification
+  const session = await serverAuth().api.getSession({
+    headers: event.headers
+  })
+
+  if (!session?.user) {
+    throw createError({
+      statusCode: 401,
+      message: 'Authentification requise'
+    })
+  }
+
+  const db = useDrizzle()
+
+  try {
+    // Vérifier que l'événement existe
+    const eventResult = await db
+      .select({
+        id: events.id,
+        maxParticipants: events.maxParticipants
+      })
+      .from(events)
+      .where(eq(events.id, id))
+      .limit(1)
+
+    if (eventResult.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: 'Événement non trouvé'
+      })
+    }
+
+    // Vérifier si l'utilisateur est déjà inscrit
+    const existingRegistration = await db
+      .select()
+      .from(eventParticipants)
+      .where(and(
+        eq(eventParticipants.eventId, id),
+        eq(eventParticipants.userId, session.user.id)
+      ))
+      .limit(1)
+
+    if (existingRegistration.length > 0) {
+      // Si déjà inscrit avec statut CANCELLED, réinscrire
+      if (existingRegistration[0]!.status === 'CANCELLED') {
+        await db
+          .update(eventParticipants)
+          .set({ status: 'REGISTERED', registeredAt: new Date() })
+          .where(and(
+            eq(eventParticipants.eventId, id),
+            eq(eventParticipants.userId, session.user.id)
+          ))
+
+        return {
+          success: true,
+          message: 'Réinscription confirmée'
+        }
+      }
+
+      throw createError({
+        statusCode: 409,
+        message: 'Vous êtes déjà inscrit à cet événement'
+      })
+    }
+
+    // Vérifier la capacité maximale
+    const evt = eventResult[0]!
+    if (evt.maxParticipants) {
+      const countResult = await db
+        .select({ count: sql<number>`count(*)` })
+        .from(eventParticipants)
+        .where(and(
+          eq(eventParticipants.eventId, id),
+          sql`${eventParticipants.status} != 'CANCELLED'`
+        ))
+
+      const currentCount = Number(countResult[0]?.count ?? 0)
+
+      if (currentCount >= evt.maxParticipants) {
+        throw createError({
+          statusCode: 409,
+          message: 'L\'événement est complet'
+        })
+      }
+    }
+
+    // Inscrire l'utilisateur
+    await db
+      .insert(eventParticipants)
+      .values({
+        eventId: id,
+        userId: session.user.id,
+        status: 'REGISTERED'
+      })
+
+    return {
+      success: true,
+      message: 'Inscription confirmée'
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur inscription événement:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de l\'inscription'
+    })
+  }
+})

--- a/server/api/events/index.get.ts
+++ b/server/api/events/index.get.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod'
+import { eq, sql, and, gte, lte } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { events, eventSports, sports, addresses } from '../../db/schema'
+
+const querySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  offset: z.coerce.number().int().min(0).default(0),
+  sport: z.string().optional(),
+  type: z.enum(['STAGE', 'TOURNOI', 'ENTRAINEMENT', 'DECOUVERTE']).optional(),
+  dateFrom: z.string().datetime().optional(),
+  dateTo: z.string().datetime().optional(),
+  city: z.string().optional(),
+  maxPrice: z.coerce.number().min(0).optional()
+})
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+
+  const parseResult = querySchema.safeParse(query)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Paramètres invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const { limit, offset, sport, type, dateFrom, dateTo, city, maxPrice } = parseResult.data
+  const db = useDrizzle()
+
+  try {
+    const conditions = []
+
+    if (type) {
+      conditions.push(eq(events.eventType, type))
+    }
+
+    if (dateFrom) {
+      conditions.push(gte(events.startTime, new Date(dateFrom)))
+    }
+
+    if (dateTo) {
+      conditions.push(lte(events.startTime, new Date(dateTo)))
+    }
+
+    if (maxPrice !== undefined) {
+      conditions.push(lte(events.price, String(maxPrice)))
+    }
+
+    if (city) {
+      conditions.push(eq(addresses.city, city))
+    }
+
+    // Filtre par sport via la table de liaison eventSports
+    if (sport) {
+      const matchingSports = await db
+        .select({ eventId: eventSports.eventId })
+        .from(eventSports)
+        .innerJoin(sports, eq(sports.id, eventSports.sportId))
+        .where(eq(sports.code, sport))
+
+      const eventIds = matchingSports.map(s => s.eventId)
+      if (eventIds.length === 0) return { data: [], total: 0, limit, offset }
+      conditions.push(sql`${events.id} = ANY(${eventIds})`)
+    }
+
+    const whereClause = conditions.length > 0 ? and(...conditions) : undefined
+
+    // Compter le total
+    const countResult = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(events)
+      .leftJoin(addresses, eq(addresses.id, events.addressId))
+      .where(whereClause)
+
+    const total = Number(countResult[0]?.count ?? 0)
+
+    // Récupérer les événements
+    const eventsList = await db
+      .select({
+        id: events.id,
+        organizerId: events.organizerId,
+        eventType: events.eventType,
+        title: events.title,
+        description: events.description,
+        startTime: events.startTime,
+        endTime: events.endTime,
+        levelRequired: events.levelRequired,
+        audience: events.audience,
+        accessibility: events.accessibility,
+        price: events.price,
+        maxParticipants: events.maxParticipants,
+        createdAt: events.createdAt,
+        address: {
+          line1: addresses.line1,
+          postalCode: addresses.postalCode,
+          city: addresses.city,
+          latitude: addresses.latitude,
+          longitude: addresses.longitude
+        }
+      })
+      .from(events)
+      .leftJoin(addresses, eq(addresses.id, events.addressId))
+      .where(whereClause)
+      .orderBy(events.startTime)
+      .limit(limit)
+      .offset(offset)
+
+    return {
+      data: eventsList,
+      total,
+      limit,
+      offset
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur liste événements:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la récupération des événements'
+    })
+  }
+})

--- a/server/api/events/index.post.ts
+++ b/server/api/events/index.post.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod'
+import { eq } from 'drizzle-orm'
+import { useDrizzle } from '../../utils/drizzle'
+import { events, eventSports, accounts } from '../../db/schema'
+import { serverAuth } from '../../utils/auth'
+
+const createEventSchema = z.object({
+  eventType: z.enum(['STAGE', 'TOURNOI', 'ENTRAINEMENT', 'DECOUVERTE']),
+  title: z.string().min(3).max(160),
+  description: z.string().min(10).optional(),
+  addressId: z.string().uuid().optional(),
+  startTime: z.string().datetime(),
+  endTime: z.string().datetime(),
+  levelRequired: z.array(z.string()).min(1),
+  audience: z.array(z.string()).min(1),
+  accessibility: z.array(z.string()).optional(),
+  paymentProvider: z.string().max(40).optional(),
+  price: z.coerce.number().min(0).default(0),
+  maxParticipants: z.coerce.number().int().min(1).optional(),
+  sportIds: z.array(z.coerce.number().int()).min(1)
+})
+
+export default defineEventHandler(async (event) => {
+  // Vérifier l'authentification
+  const session = await serverAuth().api.getSession({
+    headers: event.headers
+  })
+
+  if (!session?.user) {
+    throw createError({
+      statusCode: 401,
+      message: 'Authentification requise'
+    })
+  }
+
+  // Vérifier que le compte est de type CLUB
+  const db = useDrizzle()
+
+  const accountResult = await db
+    .select({ accountType: accounts.accountType })
+    .from(accounts)
+    .where(eq(accounts.id, session.user.id))
+    .limit(1)
+
+  if (!accountResult[0] || accountResult[0].accountType !== 'CLUB') {
+    throw createError({
+      statusCode: 403,
+      message: 'Seuls les comptes CLUB peuvent créer des événements'
+    })
+  }
+
+  const body = await readBody(event)
+
+  const parseResult = createEventSchema.safeParse(body)
+  if (!parseResult.success) {
+    throw createError({
+      statusCode: 400,
+      message: parseResult.error.errors[0]?.message || 'Données invalides',
+      data: parseResult.error.errors
+    })
+  }
+
+  const { sportIds, ...eventData } = parseResult.data
+
+  // Vérifier que startTime < endTime
+  if (new Date(eventData.startTime) >= new Date(eventData.endTime)) {
+    throw createError({
+      statusCode: 400,
+      message: 'La date de début doit être antérieure à la date de fin'
+    })
+  }
+
+  try {
+    // Créer l'événement
+    const newEvent = await db
+      .insert(events)
+      .values({
+        organizerId: session.user.id,
+        eventType: eventData.eventType,
+        title: eventData.title,
+        description: eventData.description,
+        addressId: eventData.addressId,
+        startTime: new Date(eventData.startTime),
+        endTime: new Date(eventData.endTime),
+        levelRequired: eventData.levelRequired,
+        audience: eventData.audience,
+        accessibility: eventData.accessibility,
+        paymentProvider: eventData.paymentProvider,
+        price: String(eventData.price),
+        maxParticipants: eventData.maxParticipants
+      })
+      .returning()
+
+    // Ajouter les sports liés
+    if (sportIds.length > 0) {
+      await db
+        .insert(eventSports)
+        .values(sportIds.map(sportId => ({
+          eventId: newEvent[0]!.id,
+          sportId
+        })))
+    }
+
+    return {
+      success: true,
+      message: 'Événement créé avec succès',
+      data: newEvent[0]
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    console.error('Erreur création événement:', error)
+    throw createError({
+      statusCode: 500,
+      message: 'Erreur lors de la création de l\'événement'
+    })
+  }
+})

--- a/server/db/migrations/0003_add-max-participants.sql
+++ b/server/db/migrations/0003_add-max-participants.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events" ADD COLUMN "max_participants" integer;

--- a/server/db/migrations/meta/0003_snapshot.json
+++ b/server/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,2103 @@
+{
+  "id": "79501904-8dc6-45f0-a522-c6bef1dff1b9",
+  "prevId": "6f34eb4a-19b0-483a-b017-e5851be2ab53",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_email_unique": {
+          "name": "accounts_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_accounts_account_id_accounts_id_fk": {
+          "name": "oauth_accounts_account_id_accounts_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.password_resets": {
+      "name": "password_resets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_resets_account_id_accounts_id_fk": {
+          "name": "password_resets_account_id_accounts_id_fk",
+          "tableFrom": "password_resets",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_token": {
+          "name": "session_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_account_id_accounts_id_fk": {
+          "name": "sessions_account_id_accounts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_session_token_unique": {
+          "name": "sessions_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "session_token"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.verification_codes": {
+      "name": "verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "otp_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "verification_codes_account_id_accounts_id_fk": {
+          "name": "verification_codes_account_id_accounts_id_fk",
+          "tableFrom": "verification_codes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.email_verifications": {
+      "name": "email_verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.addresses": {
+      "name": "addresses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line1": {
+          "name": "line1",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line2": {
+          "name": "line2",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'FR'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "addresses_account_id_accounts_id_fk": {
+          "name": "addresses_account_id_accounts_id_fk",
+          "tableFrom": "addresses",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.clubs": {
+      "name": "clubs",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "club_name": {
+          "name": "club_name",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "numeric(2, 1)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "review_count": {
+          "name": "review_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_open": {
+          "name": "is_open",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "website_url": {
+          "name": "website_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "logo_media_id": {
+          "name": "logo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "club_registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "offer_type": {
+          "name": "offer_type",
+          "type": "club_offer_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'ESSENTIEL'"
+        },
+        "sports": {
+          "name": "sports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_first_name": {
+          "name": "admin_first_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_last_name": {
+          "name": "admin_last_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_id": {
+          "name": "verification_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "clubs_account_id_accounts_id_fk": {
+          "name": "clubs_account_id_accounts_id_fk",
+          "tableFrom": "clubs",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.media_files": {
+      "name": "media_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "owner_account_id": {
+          "name": "owner_account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_files_owner_account_id_accounts_id_fk": {
+          "name": "media_files_owner_account_id_accounts_id_fk",
+          "tableFrom": "media_files",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "owner_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_search_prefs": {
+      "name": "user_search_prefs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base_address_id": {
+          "name": "base_address_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "radius_km": {
+          "name": "radius_km",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20.0'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_search_prefs_user_id_users_account_id_fk": {
+          "name": "user_search_prefs_user_id_users_account_id_fk",
+          "tableFrom": "user_search_prefs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "user_search_prefs_base_address_id_addresses_id_fk": {
+          "name": "user_search_prefs_base_address_id_addresses_id_fk",
+          "tableFrom": "user_search_prefs",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "base_address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_media_id": {
+          "name": "profile_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_account_id_accounts_id_fk": {
+          "name": "users_account_id_accounts_id_fk",
+          "tableFrom": "users",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_facilities": {
+      "name": "club_facilities",
+      "schema": "",
+      "columns": {
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facility": {
+          "name": "facility",
+          "type": "facility_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_facilities_club_id_clubs_account_id_fk": {
+          "name": "club_facilities_club_id_clubs_account_id_fk",
+          "tableFrom": "club_facilities",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_opening_exceptions": {
+      "name": "club_opening_exceptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_covered": {
+          "name": "date_covered",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "open_time": {
+          "name": "open_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_time": {
+          "name": "close_time",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_opening_exceptions_club_id_clubs_account_id_fk": {
+          "name": "club_opening_exceptions_club_id_clubs_account_id_fk",
+          "tableFrom": "club_opening_exceptions",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_opening_hours": {
+      "name": "club_opening_hours",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "weekday",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "morning_open": {
+          "name": "morning_open",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "morning_close": {
+          "name": "morning_close",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afternoon_open": {
+          "name": "afternoon_open",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "afternoon_close": {
+          "name": "afternoon_close",
+          "type": "time",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_opening_hours_club_id_clubs_account_id_fk": {
+          "name": "club_opening_hours_club_id_clubs_account_id_fk",
+          "tableFrom": "club_opening_hours",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_photos": {
+      "name": "club_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_photos_club_id_clubs_account_id_fk": {
+          "name": "club_photos_club_id_clubs_account_id_fk",
+          "tableFrom": "club_photos",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_reviews": {
+      "name": "club_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_reviews_club_id_clubs_account_id_fk": {
+          "name": "club_reviews_club_id_clubs_account_id_fk",
+          "tableFrom": "club_reviews",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_sports": {
+      "name": "club_sports",
+      "schema": "",
+      "columns": {
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_id": {
+          "name": "sport_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "levels_accepted": {
+          "name": "levels_accepted",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audiences": {
+          "name": "audiences",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_sports_club_id_clubs_account_id_fk": {
+          "name": "club_sports_club_id_clubs_account_id_fk",
+          "tableFrom": "club_sports",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "club_sports_sport_id_sports_id_fk": {
+          "name": "club_sports_sport_id_sports_id_fk",
+          "tableFrom": "club_sports",
+          "tableTo": "sports",
+          "columnsFrom": [
+            "sport_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.sports": {
+      "name": "sports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sports_code_unique": {
+          "name": "sports_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.event_participants": {
+      "name": "event_participants",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REGISTERED'"
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_participants_event_id_events_id_fk": {
+          "name": "event_participants_event_id_events_id_fk",
+          "tableFrom": "event_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.event_payments": {
+      "name": "event_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_payment_id": {
+          "name": "provider_payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_payments_event_id_events_id_fk": {
+          "name": "event_payments_event_id_events_id_fk",
+          "tableFrom": "event_payments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.event_photos": {
+      "name": "event_photos",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_photos_event_id_events_id_fk": {
+          "name": "event_photos_event_id_events_id_fk",
+          "tableFrom": "event_photos",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.event_sports": {
+      "name": "event_sports",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sport_id": {
+          "name": "sport_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_sports_event_id_events_id_fk": {
+          "name": "event_sports_event_id_events_id_fk",
+          "tableFrom": "event_sports",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "event_sports_sport_id_sports_id_fk": {
+          "name": "event_sports_sport_id_sports_id_fk",
+          "tableFrom": "event_sports",
+          "tableTo": "sports",
+          "columnsFrom": [
+            "sport_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level_required": {
+          "name": "level_required",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessibility": {
+          "name": "accessibility",
+          "type": "varchar[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_provider": {
+          "name": "payment_provider",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "max_participants": {
+          "name": "max_participants",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_organizer_id_accounts_id_fk": {
+          "name": "events_organizer_id_accounts_id_fk",
+          "tableFrom": "events",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_address_id_addresses_id_fk": {
+          "name": "events_address_id_addresses_id_fk",
+          "tableFrom": "events",
+          "tableTo": "addresses",
+          "columnsFrom": [
+            "address_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.admin_logs": {
+      "name": "admin_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(80)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_logs_actor_id_accounts_id_fk": {
+          "name": "admin_logs_actor_id_accounts_id_fk",
+          "tableFrom": "admin_logs",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.club_rooms": {
+      "name": "club_rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photo_media_id": {
+          "name": "photo_media_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "room_type": {
+          "name": "room_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "club_rooms_club_id_clubs_account_id_fk": {
+          "name": "club_rooms_club_id_clubs_account_id_fk",
+          "tableFrom": "club_rooms",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_account_id_accounts_id_fk": {
+          "name": "notifications_account_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OPEN'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_reporter_id_accounts_id_fk": {
+          "name": "reports_reporter_id_accounts_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.subscriptions": {
+      "name": "subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_code": {
+          "name": "plan_code",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscriptions_club_id_clubs_account_id_fk": {
+          "name": "subscriptions_club_id_clubs_account_id_fk",
+          "tableFrom": "subscriptions",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_connections": {
+      "name": "user_connections",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_id": {
+          "name": "partner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "USER",
+        "CLUB"
+      ]
+    },
+    "public.club_offer_type": {
+      "name": "club_offer_type",
+      "schema": "public",
+      "values": [
+        "ESSENTIEL",
+        "VISIBILITE"
+      ]
+    },
+    "public.club_registration_status": {
+      "name": "club_registration_status",
+      "schema": "public",
+      "values": [
+        "DRAFT",
+        "PENDING",
+        "VERIFIED",
+        "COMPLETED"
+      ]
+    },
+    "public.event_type": {
+      "name": "event_type",
+      "schema": "public",
+      "values": [
+        "STAGE",
+        "TOURNOI",
+        "ENTRAINEMENT",
+        "DECOUVERTE"
+      ]
+    },
+    "public.facility_type": {
+      "name": "facility_type",
+      "schema": "public",
+      "values": [
+        "HANDICAP_FRIENDLY",
+        "VESTIAIRES",
+        "TOILETTES"
+      ]
+    },
+    "public.otp_channel": {
+      "name": "otp_channel",
+      "schema": "public",
+      "values": [
+        "EMAIL",
+        "SMS"
+      ]
+    },
+    "public.sport_level": {
+      "name": "sport_level",
+      "schema": "public",
+      "values": [
+        "DEBUTANT",
+        "INTERMEDIAIRE",
+        "AVANCE",
+        "PRO"
+      ]
+    },
+    "public.target_audience": {
+      "name": "target_audience",
+      "schema": "public",
+      "values": [
+        "ENFANTS",
+        "ADOS",
+        "ADULTES",
+        "SENIORS",
+        "TOUS"
+      ]
+    },
+    "public.weekday": {
+      "name": "weekday",
+      "schema": "public",
+      "values": [
+        "LUN",
+        "MAR",
+        "MER",
+        "JEU",
+        "VEN",
+        "SAM",
+        "DIM"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/server/db/migrations/meta/_journal.json
+++ b/server/db/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1770127891968,
       "tag": "0002_remarkable_shen",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772103141285,
+      "tag": "0003_add-max-participants",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema/events.ts
+++ b/server/db/schema/events.ts
@@ -19,6 +19,7 @@ export const events = pgTable('events', {
   accessibility: varchar('accessibility').array(), // ex: {HANDISPORT, MIXTE}
   paymentProvider: varchar('payment_provider', { length: 40 }), // STRIPE, PAYPAL
   price: numeric('price', { precision: 10, scale: 2 }).default('0'),
+  maxParticipants: integer('max_participants'),
   createdAt: timestamp('created_at').defaultNow()
 })
 


### PR DESCRIPTION
Resolves #25 

- GET /api/events: list with filters (sport, type, date, city, price) + pagination
- GET /api/events/:id: detail with sports, photos, participants count
- POST /api/events: create (CLUB account only)
- PUT /api/events/:id: update (owner only)
- DELETE /api/events/:id: delete with cascade (owner only)
- POST /api/events/:id/register: user registration with capacity check
- DELETE /api/events/:id/register: user unregistration (status CANCELLED)
- GET /api/events/:id/participants: list participants (organizer only)
- Add maxParticipants column to events schema + migration
- Zod validation on all endpoints
- UUID validation on all :id params


## Endpoints créés

| Méthode | Route | Description | Auth |
|---------|-------|-------------|------|
| GET | /api/events | Liste avec filtres et pagination | Non |
| GET | /api/events/:id | Détail (sports, photos, participants) | Non |
| POST | /api/events | Création (compte CLUB uniquement) | CLUB |
| PUT | /api/events/:id | Modification (propriétaire) | Owner |
| DELETE | /api/events/:id | Suppression (propriétaire) | Owner |
| POST | /api/events/:id/register | Inscription utilisateur | User |
| DELETE | /api/events/:id/register | Désinscription | User |
| GET | /api/events/:id/participants | Liste participants | Organisateur |

## Filtres disponibles (GET /api/events)

- sport - code sport (via table de liaison eventSports)
- type - STAGE, TOURNOI, ENTRAINEMENT, DECOUVERTE
- dateFrom / dateTo - plage de dates ISO
- city - ville (via jointure addresses)
- maxPrice - prix maximum

## Schema

- Ajout colonne max_participants (integer, nullable) dans la table events
- Migration : 0003_add-max-participants.sql

## Sécurité

- Validation Zod sur tous les endpoints
- Validation UUID sur tous les paramètres :id
- Auth Better Auth (session cookie) sur les endpoints protégés
- Vérification accountType === CLUB pour la création
- Vérification ownership (organizerId === session.user.id) pour PUT/DELETE
- Vérification capacité maximale avant inscription
- Gestion réinscription après annulation (statut CANCELLED -> REGISTERED)

## Tests effectués

| # | Test | Résultat |
|---|------|----------|
| 1 | GET /api/events - liste vide | 200 OK |
| 2 | GET /api/events?type=STAGE - filtre valide | 200 OK |
| 3 | GET /api/events?type=INVALID - enum invalide | 400 Zod |
| 4 | GET /api/events?limit=0 - Zod reject | 400 Zod |
| 5 | GET /api/events/fake-uuid - UUID invalide | 400 |
| 6 | GET /api/events/0000...0000 - UUID inexistant | 404 |
| 7 | POST /api/events sans auth | 401 |
| 8 | POST /api/events auth USER (pas CLUB) | 403 |
| 9 | PUT /api/events/:id sans auth | 401 |
| 10 | DELETE /api/events/:id sans auth | 401 |
| 11 | POST /api/events/:id/register sans auth | 401 |
| 12 | DELETE /api/events/:id/register event inexistant | 404 |
| 13 | GET /api/events/:id/participants event inexistant | 404 |"