### PR TITLE
fix(events): update event detail link to use dashboard path

### DIFF
--- a/app/components/events/EventCreateForm.vue
+++ b/app/components/events/EventCreateForm.vue
@@ -177,7 +177,7 @@ async function handleSubmit() {
       <!-- Action buttons -->
       <div class="px-4 pb-4 flex flex-col gap-3">
         <NuxtLink
-          :to="`/events/${createdEventId}`"
+          :to="`/dashboard/events/${createdEventId}`"
           class="w-full h-10 rounded-full bg-[#ef781e] hover:bg-[#e05f16] text-white font-semibold text-base font-montserrat flex items-center justify-center gap-2 transition-colors"
         >
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Resolves #51 

 ## Summary
  - Correction du lien "Voir mon événement" après la création d'un event qui pointait vers `/events/:id` au lieu de
  `/dashboard/events/:id`

  ## Test plan
  - [X] Créer un événement en suivant les 5 étapes
  - [X] Sur l'écran de félicitation, cliquer sur "Voir mon événement"
  - [X] Vérifier que la redirection amène bien sur `/dashboard/events/:id`