### PR TITLE
refactor(inscription-club): rework club inscription flow

### DIFF
--- a/app/components/inscription/club/Step4OTP.vue
+++ b/app/components/inscription/club/Step4OTP.vue
@@ -1,0 +1,129 @@
+<script setup lang="ts">
+import type { InscriptionClubData } from '~/composables/useInscriptionClub'
+
+const props = defineProps<{
+  data: InscriptionClubData
+  isLoading: boolean
+}>()
+
+const emit = defineEmits<{
+  next: [code: string]
+  resend: []
+}>()
+
+const otpValue = ref<number[]>(props.data.verificationCode ? props.data.verificationCode.split('').map(Number) : [])
+const resendCountdown = ref(0)
+
+let countdownInterval: ReturnType<typeof setInterval> | null = null
+
+const handleResend = () => {
+  emit('resend')
+  resendCountdown.value = 60
+  countdownInterval = setInterval(() => {
+    resendCountdown.value--
+    if (resendCountdown.value <= 0) {
+      if (countdownInterval) clearInterval(countdownInterval)
+    }
+  }, 1000)
+}
+
+const onSubmit = () => {
+  if (otpValue.value.length === 6) {
+    emit('next', otpValue.value.join(''))
+  }
+}
+
+onUnmounted(() => {
+  if (countdownInterval) clearInterval(countdownInterval)
+})
+</script>
+
+<template>
+  <div class="flex flex-col flex-1 min-h-0">
+    <!-- Contenu principal centré -->
+    <div class="flex flex-col items-center gap-4">
+      <!-- Icône email -->
+      <div class="w-20 h-20 bg-[#ffedd4] rounded-full flex items-center justify-center">
+        <UIcon name="i-heroicons-envelope" class="w-10 h-10 text-tango-500" />
+      </div>
+
+      <!-- Titre et sous-titre -->
+      <div class="text-center space-y-2">
+        <h2 class="text-[30px] font-semibold text-black leading-[45px] font-[Asap]">
+          Vérifiez votre e-mail
+        </h2>
+        <p class="text-base text-[#4a5565] leading-6">
+          Nous avons envoyé un code de vérification à
+        </p>
+        <p class="text-base text-black">
+          {{ data.email }}
+        </p>
+      </div>
+
+      <!-- Code OTP -->
+      <div class="flex justify-center w-full">
+        <UPinInput
+          v-model="otpValue"
+          otp
+          type="number"
+          :length="6"
+          size="xl"
+          :disabled="isLoading"
+          :ui="{
+            base: 'w-12 h-14 rounded-2xl border-2 border-[#e5e7eb] bg-white text-black text-center focus:border-tango-500 focus:ring-0'
+          }"
+          @complete="onSubmit"
+        />
+      </div>
+
+      <!-- Renvoyer le code -->
+      <div class="text-center text-sm text-[#4a5565]">
+        Vous n'avez pas reçu le code ?
+        <button
+          v-if="resendCountdown === 0"
+          type="button"
+          class="text-tango-500 font-bold underline hover:no-underline"
+          :disabled="isLoading"
+          @click="handleResend"
+        >
+          Renvoyer
+        </button>
+        <span v-else class="text-gray-400">
+          Renvoyer ({{ resendCountdown }}s)
+        </span>
+      </div>
+    </div>
+
+    <!-- Spacer flexible -->
+    <div class="flex-1" />
+
+    <!-- Section basse avec alerte et bouton -->
+    <div class="flex flex-col gap-8">
+      <!-- Alerte spam -->
+      <UAlert
+        title="💌 Pensez à vérifier vos spams si vous ne voyez pas l'e-mail"
+        color="info"
+        variant="outline"
+        :ui="{
+          root: 'bg-[#eff6ff] border-2 border-[#dbeafe] rounded-2xl px-[18px] py-[18px]',
+          title: 'text-[#1447e6] text-sm font-normal leading-5'
+        }"
+      />
+
+      <!-- Bouton Continuer -->
+      <UButton
+        block
+        size="lg"
+        :loading="isLoading"
+        :disabled="isLoading || otpValue.length !== 6"
+        :class="[
+          'rounded-full py-2.5 font-semibold',
+          otpValue.length === 6 ? 'bg-tango-500 hover:bg-tango-600 text-white' : 'bg-[#d5d7da] text-[#212121] cursor-not-allowed'
+        ]"
+        @click="onSubmit"
+      >
+        Continuer
+      </UButton>
+    </div>
+  </div>
+</template>

--- a/app/composables/useInscriptionClub.ts
+++ b/app/composables/useInscriptionClub.ts
@@ -17,6 +17,9 @@ export interface InscriptionClubData {
   phone: string
   password: string
   confirmPassword: string
+
+  // Step 5: OTP verification
+  verificationCode: string
 }
 
 export interface InscriptionClubState {
@@ -32,7 +35,7 @@ export interface InscriptionClubState {
   clubId: string | null
 }
 
-export const TOTAL_STEPS_CLUB = 4
+export const TOTAL_STEPS_CLUB = 5
 
 export const useInscriptionClub = () => {
   const route = useRoute()
@@ -54,7 +57,8 @@ export const useInscriptionClub = () => {
       email: '',
       phone: '',
       password: '',
-      confirmPassword: ''
+      confirmPassword: '',
+      verificationCode: ''
     },
     isLoading: false,
     error: null,
@@ -122,7 +126,8 @@ export const useInscriptionClub = () => {
         email: '',
         phone: '',
         password: '',
-        confirmPassword: ''
+        confirmPassword: '',
+        verificationCode: ''
       },
       isLoading: false,
       error: null,

--- a/app/pages/inscription/club/index.vue
+++ b/app/pages/inscription/club/index.vue
@@ -2,7 +2,8 @@
 import type { InscriptionClubData } from '~/composables/useInscriptionClub'
 
 definePageMeta({
-  layout: false
+  layout: false,
+  middleware: 'guest'
 })
 
 const {
@@ -15,12 +16,7 @@ const {
 } = useInscriptionClub()
 
 const toast = useToast()
-
-// OTP verification state
-const showOtpModal = ref(false)
-const otpCode = ref('')
-const otpLoading = ref(false)
-const otpError = ref<string | null>(null)
+const { fetchSession } = useAuth()
 
 // Update sports array
 function handleSportsUpdate(sports: string[]) {
@@ -40,13 +36,12 @@ function handleBack() {
   }
 }
 
-// Step 1: Send OTP when form is submitted
+// Step 4 → 5: Send OTP then move to OTP step
 async function handleSubmit() {
   state.value.isLoading = true
   state.value.error = null
 
   try {
-    // Send OTP to verify email
     const response = await $fetch('/api/auth/send-otp', {
       method: 'POST',
       body: {
@@ -56,7 +51,7 @@ async function handleSubmit() {
     })
 
     if (response.success) {
-      showOtpModal.value = true
+      nextStep()
       toast.add({
         title: 'Code envoyé',
         description: 'Un code de vérification a été envoyé à votre adresse email',
@@ -78,47 +73,42 @@ async function handleSubmit() {
   }
 }
 
-// Step 2: Verify OTP
-async function handleVerifyOtp() {
-  if (otpCode.value.length !== 6) {
-    otpError.value = 'Le code doit contenir 6 chiffres'
-    return
-  }
-
-  otpLoading.value = true
-  otpError.value = null
+// Step 5: Verify OTP then create club
+async function handleVerifyAndCreate(code: string) {
+  state.value.isLoading = true
+  state.value.error = null
 
   try {
-    const response = await $fetch('/api/auth/verify-otp', {
+    const verifyResponse = await $fetch('/api/auth/verify-otp', {
       method: 'POST',
       body: {
         email: state.value.data.email,
-        code: otpCode.value
+        code
       }
     })
 
-    if (response.success) {
-      state.value.verificationId = response.verificationId
+    if (verifyResponse.success) {
+      state.value.verificationId = verifyResponse.verificationId
       state.value.emailVerified = true
-      showOtpModal.value = false
-
-      // Proceed to create club
       await handleCreateClub()
     }
   } catch (error: unknown) {
     console.error('Verify OTP error:', error)
-    otpError.value = error && typeof error === 'object' && 'data' in error
+    const errorMessage = error && typeof error === 'object' && 'data' in error
       ? (error.data as { message?: string })?.message || 'Code invalide'
       : 'Code invalide'
+    toast.add({
+      title: 'Erreur',
+      description: errorMessage,
+      color: 'error'
+    })
   } finally {
-    otpLoading.value = false
+    state.value.isLoading = false
   }
 }
 
-// Step 3: Create club account
+// Create club account
 async function handleCreateClub() {
-  state.value.isLoading = true
-
   try {
     const response = await $fetch<{ success: boolean, clubId: string }>('/api/clubs', {
       method: 'POST',
@@ -140,13 +130,13 @@ async function handleCreateClub() {
 
     if (response.success) {
       state.value.clubId = response.clubId
+      await fetchSession()
       toast.add({
         title: 'Club créé !',
         description: 'Votre club a été créé avec succès',
         color: 'success'
       })
 
-      // Navigate to offer selection
       await navigateTo('/inscription/club/offre')
     }
   } catch (error: unknown) {
@@ -159,16 +149,11 @@ async function handleCreateClub() {
       description: errorMessage,
       color: 'error'
     })
-  } finally {
-    state.value.isLoading = false
   }
 }
 
 // Resend OTP
 async function handleResendOtp() {
-  otpLoading.value = true
-  otpError.value = null
-
   try {
     await $fetch('/api/auth/send-otp', {
       method: 'POST',
@@ -183,14 +168,16 @@ async function handleResendOtp() {
       description: 'Un nouveau code a été envoyé à votre adresse email',
       color: 'success'
     })
-    otpCode.value = ''
   } catch (error: unknown) {
     console.error('Resend OTP error:', error)
-    otpError.value = error && typeof error === 'object' && 'data' in error
+    const errorMessage = error && typeof error === 'object' && 'data' in error
       ? (error.data as { message?: string })?.message || 'Une erreur est survenue'
       : 'Une erreur est survenue'
-  } finally {
-    otpLoading.value = false
+    toast.add({
+      title: 'Erreur',
+      description: errorMessage,
+      color: 'error'
+    })
   }
 }
 </script>
@@ -246,66 +233,15 @@ async function handleResendOtp() {
           @update="handleUpdate"
           @submit="handleSubmit"
         />
+        <InscriptionClubStep4OTP
+          v-else-if="currentStep === 5"
+          :data="state.data"
+          :is-loading="state.isLoading"
+          @next="handleVerifyAndCreate"
+          @resend="handleResendOtp"
+        />
       </Transition>
     </main>
-
-    <!-- OTP Verification Modal -->
-    <UModal v-model:open="showOtpModal">
-      <template #content>
-        <div class="p-6">
-          <div class="flex flex-col items-center gap-6">
-            <div class="text-5xl">
-              📧
-            </div>
-
-            <div class="text-center">
-              <h2 class="text-xl font-semibold text-gray-900 mb-2">
-                Vérifiez votre email
-              </h2>
-              <p class="text-gray-600">
-                Un code de vérification a été envoyé à
-                <span class="font-medium">{{ state.data.email }}</span>
-              </p>
-            </div>
-
-            <div class="w-full max-w-xs">
-              <UFormField label="Code de vérification" :error="otpError || undefined">
-                <UInput
-                  v-model="otpCode"
-                  placeholder="000000"
-                  class="w-full text-center text-2xl tracking-widest"
-                  size="xl"
-                  maxlength="6"
-                  inputmode="numeric"
-                  pattern="[0-9]*"
-                />
-              </UFormField>
-            </div>
-
-            <div class="flex flex-col gap-3 w-full max-w-xs">
-              <UButton
-                block
-                :loading="otpLoading"
-                :disabled="otpCode.length !== 6"
-                class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! rounded-[50px]! py-3!"
-                @click="handleVerifyOtp"
-              >
-                Vérifier
-              </UButton>
-
-              <button
-                type="button"
-                class="text-sm text-gray-500 hover:text-gray-700 underline"
-                :disabled="otpLoading"
-                @click="handleResendOtp"
-              >
-                Renvoyer le code
-              </button>
-            </div>
-          </div>
-        </div>
-      </template>
-    </UModal>
   </div>
 </template>
 

--- a/app/pages/inscription/club/success.vue
+++ b/app/pages/inscription/club/success.vue
@@ -7,20 +7,12 @@ function goBack() {
   navigateTo('/inscription/club/offre')
 }
 
-function addRooms() {
-  // TODO: Navigate to add rooms page
-  console.log('Add rooms')
-  navigateTo('/dashboard/club/salles/new')
-}
-
 function createEvent() {
-  // TODO: Navigate to create event page
-  console.log('Create event')
-  navigateTo('/dashboard/club/events/new')
+  navigateTo('/dashboard/mon-club/events/new')
 }
 
 function skipForNow() {
-  navigateTo('/dashboard/club')
+  navigateTo('/dashboard/mon-club')
 }
 </script>
 
@@ -97,15 +89,6 @@ function skipForNow() {
         <!-- Boutons d'action -->
         <div class="flex flex-col gap-3 w-full max-w-[352px] mt-8">
           <UButton
-            block
-            class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! font-montserrat! text-base! rounded-[50px]! py-3!"
-            @click="addRooms"
-          >
-            Ajouter des salles
-          </UButton>
-
-          <UButton
-            to="/dashboard/club"
             block
             size="lg"
             class="bg-tango-500! hover:bg-tango-600! text-white! font-semibold! font-montserrat! text-base! rounded-[50px]! py-3!"


### PR DESCRIPTION
Resolves #54 

## Summary

  - Remplace la modale OTP inline par une étape dédiée `Step4OTP.vue` (step 5), alignée visuellement sur le flow
  particulier (UPinInput 6 cases, compte à rebours 60s, alerte spam)
  - Appel `fetchSession()` après création du club pour que les middlewares `auth` reconnaissent la session sans
  rechargement
  - Supprime le bouton "Ajouter des salles" de `success.vue` et corrige les redirections vers `/dashboard/mon-club`
  - Ajoute `middleware: 'guest'` sur `/inscription/club` (index)

  ## Changes

  **`useInscriptionClub.ts`**
  - `TOTAL_STEPS_CLUB` : 4 → 5
  - Ajout du champ `verificationCode: string` dans `InscriptionClubData`

  **`Step4OTP.vue`** (nouveau)
  - Calqué sur `particulier/Step2.vue` : UPinInput, countdown 60s, alerte spam
  - Émet `next(code)` et `resend`

  **`inscription/club/index.vue`**
  - Suppression de la `UModal` OTP + états locaux (`showOtpModal`, `otpCode`, etc.)
  - `handleSubmit` (step 4) envoie l'OTP puis appelle `nextStep()` → step 5
  - Nouveau `handleVerifyAndCreate(code)` : verify-otp → create club → `fetchSession()` → navigate
  - Ajout `middleware: 'guest'`

  **`inscription/club/success.vue`**
  - Suppression du bouton "Ajouter des salles" et de `addRooms()`
  - `createEvent` → `/dashboard/mon-club/events/new`
  - `skipForNow` → `/dashboard/mon-club`

  ## Test plan

  - [X] Flow complet : sports → infos club → infos perso → OTP (step dédié) → offre → success
  - [X] Clic "Créer un événement" → redirige vers `/dashboard/mon-club/events/new` (session active)
  - [X] Clic "Je ferai ça plus tard" → redirige vers `/dashboard/mon-club`
  - [X] `/inscription/club` inaccessible si déjà connecté
  - [X] Design OTP cohérent avec le flow particulier